### PR TITLE
Add basic login, GM selector and notes

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,9 +7,12 @@ import ChatBox from '@/components/ChatBox'
 import PopupResult from '@/components/PopupResult'
 import Head from 'next/head'
 import InteractiveCanvas from '@/components/InteractiveCanvas'
-import ParamMenu from '@/components/ImportExportMenu' // ← AJOUT ICI
+import Login from '@/components/Login'
+import GMCharacterSelector from '@/components/GMCharacterSelector'
+import DiceStats from '@/components/DiceStats'
 
 export default function HomePage() {
+  const [user, setUser] = useState<string | null>(null)
   const [perso, setPerso] = useState({
     nom: 'Gustave',
     race: 'Cake',
@@ -32,8 +35,12 @@ export default function HomePage() {
   const [diceResult, setDiceResult] = useState<number | null>(null)
   const [diceDisabled, setDiceDisabled] = useState(false)
   const [pendingRoll, setPendingRoll] = useState<{ result: number, dice: number, nom: string } | null>(null)
-
+  const [history, setHistory] = useState<{ player: string, dice: number, result: number }[]>([])
   const chatBoxRef = useRef<HTMLDivElement>(null)
+
+  if (!user) {
+    return <Login onLogin={setUser} />
+  }
 
   // ⚡ Quand on lance le dé, on ne met PAS le résultat tout de suite dans le chat
   const rollDice = () => {
@@ -54,6 +61,7 @@ export default function HomePage() {
       message.innerHTML = `<strong>🎲 ${pendingRoll.nom} :</strong> D${pendingRoll.dice} → <strong>${pendingRoll.result}</strong>`
       chatBoxRef.current.appendChild(message)
       chatBoxRef.current.scrollTop = chatBoxRef.current.scrollHeight
+      setHistory(h => [...h, { player: user || pendingRoll.nom, dice: pendingRoll.dice, result: pendingRoll.result }])
       setPendingRoll(null)
     }
   }
@@ -63,6 +71,9 @@ export default function HomePage() {
       <Head>
         <title>CakeJDR</title>
       </Head>
+      <div className="absolute top-2 left-2 z-50">
+        <GMCharacterSelector onSelect={setPerso} />
+      </div>
 
       <CharacterSheet perso={perso} onUpdate={setPerso} chatBoxRef={chatBoxRef} />
 
@@ -86,6 +97,9 @@ export default function HomePage() {
       </main>
 
       <ChatBox chatBoxRef={chatBoxRef} />
+      <aside className="w-1/5 bg-gray-100 dark:bg-gray-800 overflow-y-auto">
+        <DiceStats history={history} />
+      </aside>
     </div>
   )
 }

--- a/components/CharacterSheet.tsx
+++ b/components/CharacterSheet.tsx
@@ -9,13 +9,15 @@ import DescriptionPanel from './DescriptionPanel'
 import LevelUpPanel from './LevelUpPanel'
 import ImportExportMenu from './ImportExportMenu'
 import CharacterSheetHeader from './CharacterSheetHeader'
+import NotesPanel from './NotesPanel'
 
 // (ImportExportMenu ici plus tard)
 
 const TABS = [
   { key: 'main', label: 'Statistiques' },
   { key: 'equip', label: 'Équipement' },
-  { key: 'desc', label: 'Description' }
+  { key: 'desc', label: 'Description' },
+  { key: 'notes', label: 'Notes' }
 ]
 
 type Competence = { nom: string, type: string, effets: string, degats?: string }
@@ -62,6 +64,7 @@ export const defaultPerso = {
   avantages: '',
   background: '',
   champs_perso: [],
+  notes: ''
 }
 
 const CharacterSheet: FC<Props> = ({ perso, onUpdate, chatBoxRef }) => {
@@ -269,6 +272,14 @@ const CharacterSheet: FC<Props> = ({ perso, onUpdate, chatBoxRef }) => {
             arr[idx] = champ
             setLocalPerso({ ...localPerso, champs_perso: arr })
           }}
+        />
+      )}
+
+      {tab === 'notes' && (
+        <NotesPanel
+          edit={edit}
+          value={localPerso.notes || ''}
+          onChange={txt => handleChange('notes', txt)}
         />
       )}
 

--- a/components/DiceStats.tsx
+++ b/components/DiceStats.tsx
@@ -1,0 +1,70 @@
+'use client'
+import { useMemo, useState } from 'react'
+
+type Roll = { player: string, dice: number, result: number }
+
+type Props = { history: Roll[] }
+
+function computeStats(history: Roll[]) {
+  const stats: Record<string, { rolls: number, crit: number, fail: number, dist: Record<number, number> }> = {}
+  for (const h of history) {
+    if (!stats[h.player]) stats[h.player] = { rolls: 0, crit: 0, fail: 0, dist: {} }
+    const s = stats[h.player]
+    s.rolls++
+    if (h.result === 1) s.fail++
+    if (h.result === h.dice) s.crit++
+    s.dist[h.dice] = (s.dist[h.dice] || 0) + 1
+  }
+  return stats
+}
+
+export default function DiceStats({ history }: Props) {
+  const [selected, setSelected] = useState<string>('all')
+  const stats = useMemo(() => computeStats(history), [history])
+  const players = Object.keys(stats)
+
+  const renderRow = (player: string) => {
+    const s = stats[player]
+    return (
+      <tr key={player} className="border-b border-gray-700">
+        <td className="px-2 py-1 font-semibold">{player}</td>
+        <td className="px-2 py-1 text-center">{s.rolls}</td>
+        <td className="px-2 py-1 text-center">{s.crit}</td>
+        <td className="px-2 py-1 text-center">{s.fail}</td>
+        <td className="px-2 py-1 text-sm">{Object.entries(s.dist).map(([d,c]) => `D${d}:${c}`).join(' ')}</td>
+      </tr>
+    )
+  }
+
+  if (players.length === 0) return <div className="p-2 text-sm">Aucun jet enregistré.</div>
+
+  return (
+    <div className="p-2">
+      <div className="mb-2">
+        <label className="mr-2">Voir stats :</label>
+        <select
+          value={selected}
+          onChange={e => setSelected(e.target.value)}
+          className="bg-gray-800 text-white rounded px-2 py-1 text-sm"
+        >
+          <option value="all">Tous les joueurs</option>
+          {players.map(p => <option key={p} value={p}>{p}</option>)}
+        </select>
+      </div>
+      <table className="text-sm w-full text-left border-collapse">
+        <thead>
+          <tr className="bg-gray-800 text-white">
+            <th className="px-2 py-1">Joueur</th>
+            <th className="px-2 py-1">Jets</th>
+            <th className="px-2 py-1">Critiques</th>
+            <th className="px-2 py-1">Echecs</th>
+            <th className="px-2 py-1">Par dé</th>
+          </tr>
+        </thead>
+        <tbody>
+          {selected === 'all' ? players.map(renderRow) : renderRow(selected)}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/components/GMCharacterSelector.tsx
+++ b/components/GMCharacterSelector.tsx
@@ -1,0 +1,74 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+// Liste des fiches dans localStorage utilisée par MenuAccueil
+const STORAGE_KEY = 'jdr_characters'
+
+type Character = { id: number, name: string }
+
+type Props = {
+  onSelect: (char: Character) => void
+}
+
+export default function GMCharacterSelector({ onSelect }: Props) {
+  const [chars, setChars] = useState<Character[]>([])
+  const [open, setOpen] = useState(false)
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+
+  // Chargement initial
+  useEffect(() => {
+    setChars(loadCharacters())
+  }, [])
+
+  // Rafraîchissement périodique
+  useEffect(() => {
+    if (selectedId === null) return
+    const interval = setInterval(() => {
+      const list = loadCharacters()
+      const found = list.find(c => c.id === selectedId)
+      if (found) onSelect(found)
+    }, 5000)
+    return () => clearInterval(interval)
+  }, [selectedId])
+
+  const loadCharacters = () => {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]')
+    } catch {
+      return []
+    }
+  }
+
+  const refreshList = () => {
+    setChars(loadCharacters())
+  }
+
+  const handleSelect = (id: number) => {
+    setSelectedId(id)
+    const list = loadCharacters()
+    const found = list.find(c => c.id === id)
+    if (found) onSelect(found)
+    setOpen(false)
+  }
+
+  return (
+    <div className="relative inline-block ml-2">
+      <button
+        onClick={() => { refreshList(); setOpen(o => !o) }}
+        className="px-2 py-1 bg-gray-800 text-white rounded text-xs"
+      >Changer de perso</button>
+      {open && (
+        <div className="absolute right-0 mt-2 bg-gray-900 text-white rounded shadow-xl p-2 z-50">
+          {chars.length === 0 && <div className="px-2">Aucun perso</div>}
+          {chars.map(c => (
+            <button
+              key={c.id}
+              onClick={() => handleSelect(c.id)}
+              className="block text-left w-full px-3 py-1 hover:bg-gray-700 rounded"
+            >{c.name}</button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -1,0 +1,38 @@
+'use client'
+import { useState, useEffect } from 'react'
+
+interface Props { onLogin: (name: string) => void }
+
+const STORAGE_KEY = 'cakejdr_user'
+
+export default function Login({ onLogin }: Props) {
+  const [name, setName] = useState('')
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved) onLogin(saved)
+  }, [onLogin])
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const trimmed = name.trim()
+    if (!trimmed) return
+    localStorage.setItem(STORAGE_KEY, trimmed)
+    onLogin(trimmed)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="h-screen flex items-center justify-center bg-gray-900 text-white">
+      <div className="bg-gray-800 p-6 rounded shadow-lg">
+        <label className="block mb-2">Pseudo :</label>
+        <input
+          type="text"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          className="px-2 py-1 rounded text-black"
+        />
+        <button type="submit" className="ml-2 px-3 py-1 bg-blue-600 rounded text-white">Entrer</button>
+      </div>
+    </form>
+  )
+}

--- a/components/MenuAccueil.tsx
+++ b/components/MenuAccueil.tsx
@@ -132,7 +132,8 @@ export default function MenuAccueil() {
    * Rendu JSX – Tailwind pour layout simple.
    * -------------------------------------------------------------------*/
   return (
-    <div className="mx-auto max-w-2xl p-4 space-y-6">
+    <div className="min-h-screen bg-gradient-to-br from-purple-800 to-blue-800 p-4 text-white">
+      <div className="mx-auto max-w-2xl space-y-6">
       {/* ---------------- Profil ---------------- */}
       <section className="bg-white rounded-2xl shadow p-6">
         <h2 className="text-xl font-bold mb-4">Profil</h2>
@@ -222,6 +223,7 @@ export default function MenuAccueil() {
           </pre>
         </section>
       )}
+      </div>
     </div>
   );
 }

--- a/components/NotesPanel.tsx
+++ b/components/NotesPanel.tsx
@@ -1,0 +1,34 @@
+'use client'
+import { useState, useEffect } from 'react'
+
+interface Props {
+  edit: boolean
+  value: string
+  onChange: (txt: string) => void
+}
+
+export default function NotesPanel({ edit, value, onChange }: Props) {
+  const [local, setLocal] = useState(value || '')
+
+  useEffect(() => setLocal(value || ''), [value])
+
+
+  const handleBlur = () => {
+    onChange(local)
+  }
+
+  return (
+    <div className="p-2">
+      {edit ? (
+        <textarea
+          className="w-full h-40 bg-white text-black p-2 rounded border"
+          value={local}
+          onChange={e => setLocal(e.target.value)}
+          onBlur={handleBlur}
+        />
+      ) : (
+        <pre className="whitespace-pre-wrap bg-gray-200 dark:bg-gray-700 p-2 rounded" style={{ minHeight: '160px' }}>{local}</pre>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create GMCharacterSelector with auto-refresh
- add NotesPanel and integrate new "notes" tab
- implement DiceStats component for roll statistics
- add Login page and integrate with HomePage
- refresh MenuAccueil design

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b6bc2be24832e85ef67722eb51f70