### PR TITLE
Add collapsible dice stats and menu link

### DIFF
--- a/app/menu/page.tsx
+++ b/app/menu/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+import MenuAccueil from '@/components/MenuAccueil'
+import Link from 'next/link'
+
+export default function MenuPage() {
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      <div className="p-4">
+        <Link href="/" className="bg-gray-800 px-3 py-1 rounded">Retour au jeu</Link>
+      </div>
+      <MenuAccueil />
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ import Head from 'next/head'
 import InteractiveCanvas from '@/components/InteractiveCanvas'
 import Login from '@/components/Login'
 import GMCharacterSelector from '@/components/GMCharacterSelector'
-import DiceStats from '@/components/DiceStats'
+import Link from 'next/link'
 
 export default function HomePage() {
   const [user, setUser] = useState<string | null>(null)
@@ -71,7 +71,8 @@ export default function HomePage() {
       <Head>
         <title>CakeJDR</title>
       </Head>
-      <div className="absolute top-2 left-2 z-50">
+      <div className="absolute top-2 left-2 z-50 flex gap-2">
+        <Link href="/menu" className="bg-gray-800 text-white px-2 py-1 rounded text-sm">Menu</Link>
         <GMCharacterSelector onSelect={setPerso} />
       </div>
 
@@ -96,10 +97,7 @@ export default function HomePage() {
         />
       </main>
 
-      <ChatBox chatBoxRef={chatBoxRef} />
-      <aside className="w-1/5 bg-gray-100 dark:bg-gray-800 overflow-y-auto">
-        <DiceStats history={history} />
-      </aside>
+      <ChatBox chatBoxRef={chatBoxRef} history={history} />
     </div>
   )
 }

--- a/components/ChatBox.tsx
+++ b/components/ChatBox.tsx
@@ -1,18 +1,23 @@
 'use client'
 import { FC, RefObject, useRef, useState, useEffect } from 'react'
 import SummaryPanel from './SummaryPanel'
+import DiceStats from './DiceStats'
+
+type Roll = { player: string, dice: number, result: number }
 
 type Props = {
   chatBoxRef: RefObject<HTMLDivElement | null>
+  history: Roll[]
 }
 
-const ChatBox: FC<Props> = ({ chatBoxRef }) => {
+const ChatBox: FC<Props> = ({ chatBoxRef, history }) => {
   const [messages, setMessages] = useState([
     { author: 'MJ', text: 'Bienvenue !' }
   ])
   const [inputValue, setInputValue] = useState('')
   const endRef = useRef<HTMLDivElement>(null)
   const [showSummary, setShowSummary] = useState(false)
+  const [showStats, setShowStats] = useState(false)
   // Les actes peuvent aussi être stockés plus globalement si besoin
 
   const sendMessage = () => {
@@ -27,14 +32,30 @@ const ChatBox: FC<Props> = ({ chatBoxRef }) => {
 
   return (
     <aside className="w-1/5 bg-gray-200 dark:bg-gray-800 p-4 flex flex-col relative">
-      {/* Bouton résumé */}
-      <div className="flex justify-center items-center mb-2">
+      {/* Boutons en-tête */}
+      <div className="flex justify-center items-center mb-2 gap-2">
         <button
           className="bg-yellow-400 hover:bg-yellow-500 text-gray-900 px-4 py-1 rounded shadow font-bold text-sm"
           onClick={() => setShowSummary(true)}
         >
           Résumé de la partie
         </button>
+        <button
+          className="bg-gray-700 text-white px-2 py-1 rounded text-sm"
+          onClick={() => setShowStats(s => !s)}
+        >
+          {showStats ? '▶' : '📊'}
+        </button>
+      </div>
+
+      {/* Panel stats */}
+      <div
+        className={`absolute top-0 left-full h-full w-64 bg-gray-100 dark:bg-gray-900 shadow-lg transition-transform ${showStats ? 'translate-x-0' : 'translate-x-full'}`}
+      >
+        <div className="p-2 flex justify-end">
+          <button className="text-sm" onClick={() => setShowStats(false)}>✖</button>
+        </div>
+        <DiceStats history={history} />
       </div>
 
       {!showSummary && (


### PR DESCRIPTION
## Summary
- add toggleable dice stats panel inside ChatBox
- link to the new Menu page from the game page
- show character selection menu at `/menu`

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b7f00bde8832eb75182ddd045f8a9