### PR TITLE
UI enhancements and character modal

### DIFF
--- a/components/ChatBox.tsx
+++ b/components/ChatBox.tsx
@@ -44,21 +44,11 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history }) => {
           className="bg-gray-700 text-white px-2 py-1 rounded text-sm"
           onClick={() => setShowStats(s => !s)}
         >
-          {showStats ? '▶' : '📊'}
+          {showStats ? 'Chat' : '📊'}
         </button>
       </div>
 
-      {/* Panel stats */}
-      <div
-        className={`absolute top-0 left-full h-full w-64 bg-gray-100 dark:bg-gray-900 shadow-lg transition-transform ${showStats ? 'translate-x-0' : 'translate-x-full'}`}
-      >
-        <div className="p-2 flex justify-end">
-          <button className="text-sm" onClick={() => setShowStats(false)}>✖</button>
-        </div>
-        <DiceStats history={history} />
-      </div>
-
-      {!showSummary && (
+      {!showSummary && !showStats && (
         <>
           <h2 className="text-xl font-bold mb-4 text-center">Chat</h2>
 
@@ -94,6 +84,12 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history }) => {
             </button>
           </div>
         </>
+      )}
+
+      {showStats && (
+        <div className="flex-1 overflow-y-auto bg-white dark:bg-gray-700 p-2 rounded shadow">
+          <DiceStats history={history} />
+        </div>
       )}
 
       {showSummary && (

--- a/components/GMCharacterSelector.tsx
+++ b/components/GMCharacterSelector.tsx
@@ -7,7 +7,8 @@ const STORAGE_KEY = 'jdr_characters'
 type Character = { id: number, name: string }
 
 type Props = {
-  onSelect: (char: Character) => void
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onSelect: (char: any) => void
 }
 
 export default function GMCharacterSelector({ onSelect }: Props) {
@@ -25,7 +26,8 @@ export default function GMCharacterSelector({ onSelect }: Props) {
     if (selectedId === null) return
     const interval = setInterval(() => {
       const list = loadCharacters()
-      const found = list.find(c => c.id === selectedId)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const found = list.find((c: any) => c.id === selectedId)
       if (found) onSelect(found)
     }, 5000)
     return () => clearInterval(interval)
@@ -46,7 +48,8 @@ export default function GMCharacterSelector({ onSelect }: Props) {
   const handleSelect = (id: number) => {
     setSelectedId(id)
     const list = loadCharacters()
-    const found = list.find(c => c.id === id)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const found = list.find((c: any) => c.id === id)
     if (found) onSelect(found)
     setOpen(false)
   }


### PR DESCRIPTION
## Summary
- toggle chat/stats view directly in ChatBox
- redesign profile menu with color picker circles
- add character creation modal using existing sheet
- relax types in GMCharacterSelector

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b814bbe84832e9d5e5df9f6623e05