### PR TITLE
Improve menu and dynamic profiles

### DIFF
--- a/components/CharacterSheetHeader.tsx
+++ b/components/CharacterSheetHeader.tsx
@@ -43,11 +43,11 @@ const CharacterSheetHeader: FC<Props> = ({
           </button>
         </div>
       </div>
-      <nav className="flex gap-1 mt-2">
+      <nav className="flex gap-2 mt-2">
         {TABS.map(t => (
           <button
             key={t.key}
-            className={`px-2 py-1 rounded-t text-sm font-semibold ${tab === t.key ? 'bg-blue-600 text-white' : 'bg-gray-700 text-gray-200'}`}
+            className={`px-3 py-2 rounded-t text-base font-semibold ${tab === t.key ? 'bg-blue-600 text-white' : 'bg-gray-700 text-gray-200'}`}
             onClick={() => setTab(t.key)}
           >
             {t.label}

--- a/components/ChatBox.tsx
+++ b/components/ChatBox.tsx
@@ -2,6 +2,7 @@
 import { FC, RefObject, useRef, useState, useEffect } from 'react'
 import SummaryPanel from './SummaryPanel'
 import DiceStats from './DiceStats'
+import OnlineProfiles from './OnlineProfiles'
 
 type Roll = { player: string, dice: number, result: number }
 
@@ -65,7 +66,8 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history }) => {
             <div ref={endRef} />
           </div>
 
-          <div className="mt-4 flex">
+          <div className="mt-4 flex items-center">
+            <OnlineProfiles />
             <input
               type="text"
               placeholder="Votre message..."

--- a/components/DiceStats.tsx
+++ b/components/DiceStats.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 type Roll = { player: string, dice: number, result: number }
 
@@ -20,7 +20,10 @@ function computeStats(history: Roll[]) {
 
 export default function DiceStats({ history }: Props) {
   const [selected, setSelected] = useState<string>('all')
-  const stats = useMemo(() => computeStats(history), [history])
+  const [stats, setStats] = useState(() => computeStats(history))
+  useEffect(() => {
+    setStats(computeStats(history))
+  }, [history])
   const players = Object.keys(stats)
 
   const renderRow = (player: string) => {

--- a/components/GMCharacterSelector.tsx
+++ b/components/GMCharacterSelector.tsx
@@ -16,9 +16,16 @@ export default function GMCharacterSelector({ onSelect }: Props) {
   const [open, setOpen] = useState(false)
   const [selectedId, setSelectedId] = useState<number | null>(null)
 
-  // Chargement initial
+  // Chargement initial + écoute des modifications
   useEffect(() => {
-    setChars(loadCharacters())
+    const update = () => setChars(loadCharacters())
+    update()
+    window.addEventListener('storage', update)
+    window.addEventListener('jdr_characters_change', update as EventListener)
+    return () => {
+      window.removeEventListener('storage', update)
+      window.removeEventListener('jdr_characters_change', update as EventListener)
+    }
   }, [])
 
   // Rafraîchissement périodique

--- a/components/ImportExportMenu.tsx
+++ b/components/ImportExportMenu.tsx
@@ -12,6 +12,22 @@ type Props = {
 }
 
 const LOCAL_KEY = 'cakejdr_perso'
+const CHAR_LIST_KEY = 'jdr_characters'
+
+const addToList = (char: any) => {
+  try {
+    const list = JSON.parse(localStorage.getItem(CHAR_LIST_KEY) || '[]')
+    const withName = { ...char, name: char.name || char.nom }
+    const exists = list.find((c: any) => c.id === withName.id)
+    const updated = exists
+      ? list.map((c: any) => c.id === withName.id ? withName : c)
+      : [...list, withName]
+    localStorage.setItem(CHAR_LIST_KEY, JSON.stringify(updated))
+    window.dispatchEvent(new Event('jdr_characters_change'))
+  } catch {
+    /* empty */
+  }
+}
 
 const ImportExportMenu: FC<Props> = ({ perso, onUpdate }) => {
   const [open, setOpen] = useState(false)
@@ -41,6 +57,7 @@ const ImportExportMenu: FC<Props> = ({ perso, onUpdate }) => {
         const data = JSON.parse(txt)
         if (!data || typeof data !== "object") throw new Error()
         onUpdate(data)
+        addToList({ ...data, id: data.id || Date.now() })
         alert('Fiche importée avec succès !')
       } catch {
         alert('Erreur lors de l\'import : le fichier doit être un fichier texte au format JSON.')
@@ -66,6 +83,7 @@ const ImportExportMenu: FC<Props> = ({ perso, onUpdate }) => {
         const obj = JSON.parse(data)
         if (!obj || typeof obj !== "object") throw new Error()
         onUpdate(obj)
+        addToList({ ...obj, id: obj.id || Date.now() })
         alert('Fiche chargée depuis la sauvegarde locale !')
       } catch {
         alert('Erreur lors du chargement local.')

--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -3,21 +3,34 @@ import { useState, useEffect } from 'react'
 
 interface Props { onLogin: (name: string) => void }
 
-const STORAGE_KEY = 'cakejdr_user'
+const PROFILE_KEY = 'jdr_profile'
 
 export default function Login({ onLogin }: Props) {
   const [name, setName] = useState('')
 
   useEffect(() => {
-    const saved = localStorage.getItem(STORAGE_KEY)
-    if (saved) onLogin(saved)
+    try {
+      const saved = localStorage.getItem(PROFILE_KEY)
+      if (saved) {
+        const prof = JSON.parse(saved)
+        if (prof.pseudo) onLogin(prof.pseudo)
+        setName(prof.pseudo || '')
+      }
+    } catch {
+      /* empty */
+    }
   }, [onLogin])
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     const trimmed = name.trim()
     if (!trimmed) return
-    localStorage.setItem(STORAGE_KEY, trimmed)
+    const existing = (() => {
+      try { return JSON.parse(localStorage.getItem(PROFILE_KEY) || '{}') } catch { return {} }
+    })()
+    const updated = { ...existing, pseudo: trimmed }
+    localStorage.setItem(PROFILE_KEY, JSON.stringify(updated))
+    window.dispatchEvent(new Event('jdr_profile_change'))
     onLogin(trimmed)
   }
 

--- a/components/OnlineProfiles.tsx
+++ b/components/OnlineProfiles.tsx
@@ -1,0 +1,45 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+interface Profile { pseudo: string; color: string }
+
+const STORAGE_KEY = 'jdr_online'
+
+function readProfiles(): Record<string, Profile> {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}') as Record<string, Profile>
+  } catch {
+    return {}
+  }
+}
+
+export default function OnlineProfiles() {
+  const [profiles, setProfiles] = useState<Record<string, Profile>>({})
+
+  useEffect(() => {
+    const update = () => setProfiles(readProfiles())
+    update()
+    window.addEventListener('storage', update)
+    window.addEventListener('jdr_online_change', update as EventListener)
+    return () => {
+      window.removeEventListener('storage', update)
+      window.removeEventListener('jdr_online_change', update as EventListener)
+    }
+  }, [])
+
+  const entries = Object.entries(profiles)
+  if (entries.length === 0) return null
+
+  return (
+    <div className="flex gap-1 mr-2">
+      {entries.map(([id, p]) => (
+        <div
+          key={id}
+          className="w-4 h-4 rounded-full border border-white"
+          style={{ backgroundColor: p.color }}
+          title={p.pseudo}
+        />
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- update dice stats live with history changes
- display connected profiles in chat
- add online profile management utilities
- refresh character lists across pages
- redesign menu profile section with MJ option
- enlarge character sheet tabs
- unify login profile handling

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b8e8d7524832ea8801cad74b24335