### PR TITLE
UI improvements

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import ChatBox from '@/components/ChatBox'
 import PopupResult from '@/components/PopupResult'
 import Head from 'next/head'
 import InteractiveCanvas from '@/components/InteractiveCanvas'
+import OnlineProfiles from '@/components/OnlineProfiles'
 import Login from '@/components/Login'
 import GMCharacterSelector from '@/components/GMCharacterSelector'
 import Link from 'next/link'
@@ -151,6 +152,9 @@ export default function HomePage() {
 
       <main className="flex-1 bg-white dark:bg-gray-950 flex flex-col">
         <div className="flex-1 border m-4 bg-gray-50 dark:bg-gray-900 flex flex-col justify-center items-center relative">
+          <div className="absolute left-2 bottom-2 flex gap-1 z-40">
+            <OnlineProfiles />
+          </div>
           <InteractiveCanvas />
           <PopupResult
             show={showPopup}

--- a/components/CharacterSheet.tsx
+++ b/components/CharacterSheet.tsx
@@ -29,7 +29,8 @@ type Props = {
   perso: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onUpdate: (perso: any) => void,
-  chatBoxRef?: React.RefObject<HTMLDivElement | null>
+  chatBoxRef?: React.RefObject<HTMLDivElement | null>,
+  creation?: boolean
 }
 
 export const defaultPerso = {
@@ -67,8 +68,8 @@ export const defaultPerso = {
   notes: ''
 }
 
-const CharacterSheet: FC<Props> = ({ perso, onUpdate, chatBoxRef }) => {
-  const [edit, setEdit] = useState(false)
+const CharacterSheet: FC<Props> = ({ perso, onUpdate, chatBoxRef, creation = false }) => {
+  const [edit, setEdit] = useState(creation)
   const [tab, setTab] = useState('main')
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [localPerso, setLocalPerso] = useState<any>(
@@ -156,26 +157,28 @@ const CharacterSheet: FC<Props> = ({ perso, onUpdate, chatBoxRef }) => {
     <aside
       className="bg-gray-900 pt-0 pb-3 px-3 overflow-y-auto text-[15px] text-white relative select-none"
       style={{
-        width: '420px',       // Largeur fixe (cohérent partout)
-        minWidth: '420px',
-        maxWidth: '420px',
+        width: creation ? 'auto' : '420px',
+        minWidth: creation ? '600px' : '420px',
+        maxWidth: creation ? '100%' : '420px',
         boxSizing: 'border-box',
         overflowX: 'hidden'
       }}
     >
 
-      <CharacterSheetHeader
-        edit={edit}
-        onToggleEdit={() => setEdit(true)}
-        onSave={save}
-        tab={tab}
-        setTab={setTab}
-        TABS={TABS}
-      >
-        <ImportExportMenu perso={edit ? localPerso : cFiche} onUpdate={onUpdate} />
-      </CharacterSheetHeader>
+      {!creation && (
+        <CharacterSheetHeader
+          edit={edit}
+          onToggleEdit={() => setEdit(true)}
+          onSave={save}
+          tab={tab}
+          setTab={setTab}
+          TABS={TABS}
+        >
+          <ImportExportMenu perso={edit ? localPerso : cFiche} onUpdate={onUpdate} />
+        </CharacterSheetHeader>
+      )}
 
-      {tab === 'main' && (
+      {(creation || tab === 'main') && (
         <>
           <StatsPanel
             edit={edit}
@@ -209,8 +212,7 @@ const CharacterSheet: FC<Props> = ({ perso, onUpdate, chatBoxRef }) => {
           />
         </>
       )}
-
-      {tab === 'equip' && (
+      {(creation || tab === 'equip') && (
         <EquipPanel
           edit={edit}
           armes={localPerso.armes}
@@ -234,7 +236,7 @@ const CharacterSheet: FC<Props> = ({ perso, onUpdate, chatBoxRef }) => {
         />
       )}
 
-      {tab === 'desc' && (
+      {(creation || tab === 'desc') && (
         <DescriptionPanel
           edit={edit}
           values={{
@@ -275,7 +277,7 @@ const CharacterSheet: FC<Props> = ({ perso, onUpdate, chatBoxRef }) => {
         />
       )}
 
-      {tab === 'notes' && (
+      {(creation || tab === 'notes') && (
         <NotesPanel
           edit={edit}
           value={localPerso.notes || ''}

--- a/components/ChatBox.tsx
+++ b/components/ChatBox.tsx
@@ -2,7 +2,6 @@
 import { FC, RefObject, useRef, useState, useEffect } from 'react'
 import SummaryPanel from './SummaryPanel'
 import DiceStats from './DiceStats'
-import OnlineProfiles from './OnlineProfiles'
 
 type Roll = { player: string, dice: number, result: number }
 
@@ -67,7 +66,6 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history }) => {
           </div>
 
           <div className="mt-4 flex items-center">
-            <OnlineProfiles />
             <input
               type="text"
               placeholder="Votre message..."

--- a/components/DiceStats.tsx
+++ b/components/DiceStats.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 type Roll = { player: string, dice: number, result: number }
 
@@ -20,10 +20,7 @@ function computeStats(history: Roll[]) {
 
 export default function DiceStats({ history }: Props) {
   const [selected, setSelected] = useState<string>('all')
-  const [stats, setStats] = useState(() => computeStats(history))
-  useEffect(() => {
-    setStats(computeStats(history))
-  }, [history])
+  const stats = computeStats(history)
   const players = Object.keys(stats)
 
   const renderRow = (player: string) => {

--- a/components/GMCharacterSelector.tsx
+++ b/components/GMCharacterSelector.tsx
@@ -15,6 +15,7 @@ export default function GMCharacterSelector({ onSelect }: Props) {
   const [chars, setChars] = useState<Character[]>([])
   const [open, setOpen] = useState(false)
   const [selectedId, setSelectedId] = useState<number | null>(null)
+  const selectedName = chars.find(c => c.id === selectedId)?.name || ''
 
   // Chargement initial + écoute des modifications
   useEffect(() => {
@@ -62,11 +63,12 @@ export default function GMCharacterSelector({ onSelect }: Props) {
   }
 
   return (
-    <div className="relative inline-block ml-2">
+    <div className="relative inline-flex items-center ml-2 text-white bg-gray-800 rounded px-2 py-1 gap-2">
       <button
         onClick={() => { refreshList(); setOpen(o => !o) }}
-        className="px-2 py-1 bg-gray-800 text-white rounded text-xs"
-      >Changer de perso</button>
+        className="px-2 py-1 bg-gray-700 text-white rounded text-xs"
+      >Changer</button>
+      {selectedName && <span className="text-sm">{selectedName}</span>}
       {open && (
         <div className="absolute right-0 mt-2 bg-gray-900 text-white rounded shadow-xl p-2 z-50">
           {chars.length === 0 && <div className="px-2">Aucun perso</div>}

--- a/components/MenuAccueil.tsx
+++ b/components/MenuAccueil.tsx
@@ -186,7 +186,7 @@ const handleProfileChange = (field: string) => (e: React.ChangeEvent<HTMLInputEl
               onChange={handleProfileChange('isMJ')}
               className="form-checkbox"
             />
-            <label htmlFor="mjCheck" className="font-semibold">Je suis MJ</label>
+            <label htmlFor="mjCheck" className="font-semibold">MJ</label>
           </div>
           <button
             onClick={handleSaveProfile}
@@ -258,7 +258,7 @@ const handleProfileChange = (field: string) => (e: React.ChangeEvent<HTMLInputEl
     {modalOpen && (
       <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
         <div className="bg-gray-800 p-4 rounded overflow-y-auto max-h-full">
-          <CharacterSheet perso={draftChar} onUpdate={setDraftChar} />
+          <CharacterSheet perso={draftChar} onUpdate={setDraftChar} creation />
           <div className="flex justify-end gap-2 mt-2">
             <button
               onClick={() => setModalOpen(false)}

--- a/components/OnlineProfiles.tsx
+++ b/components/OnlineProfiles.tsx
@@ -31,7 +31,7 @@ export default function OnlineProfiles() {
   if (entries.length === 0) return null
 
   return (
-    <div className="flex gap-1 mr-2">
+    <div className="flex gap-1">
       {entries.map(([id, p]) => (
         <div
           key={id}


### PR DESCRIPTION
## Summary
- display online profiles below the canvas
- show selected character name in GM selector
- support large creation mode for character sheet
- simplify dice stats refresh
- tidy profile checkbox label

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b92b00aa4832e87ff14a432521862