### PR TITLE
UI improvements

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,13 +7,15 @@ import ChatBox from '@/components/ChatBox'
 import PopupResult from '@/components/PopupResult'
 import Head from 'next/head'
 import InteractiveCanvas from '@/components/InteractiveCanvas'
+import OnlineProfiles from '@/components/OnlineProfiles'
+import SideNotes from '@/components/SideNotes'
 import Login from '@/components/Login'
 import GMCharacterSelector from '@/components/GMCharacterSelector'
 import Link from 'next/link'
 
 export default function HomePage() {
   const [user, setUser] = useState<string | null>(null)
-  const [profile, setProfile] = useState<{ pseudo: string, color: string }>({ pseudo: '', color: '#ffffff' })
+  const [profile, setProfile] = useState<{ pseudo: string, color: string, isMJ: boolean }>({ pseudo: '', color: '#ffffff', isMJ: false })
   const [perso, setPerso] = useState({
     nom: 'Gustave',
     race: 'Cake',
@@ -80,7 +82,7 @@ export default function HomePage() {
         const p = JSON.parse(saved)
         if (p.pseudo) {
           setUser(p.pseudo)
-          setProfile({ pseudo: p.pseudo, color: p.color || '#ffffff' })
+          setProfile({ pseudo: p.pseudo, color: p.color || '#ffffff', isMJ: !!p.isMJ })
         }
       }
     } catch {
@@ -95,7 +97,7 @@ export default function HomePage() {
         const saved = localStorage.getItem('jdr_profile')
         if (saved) {
           const p = JSON.parse(saved)
-          setProfile({ pseudo: p.pseudo || '', color: p.color || '#ffffff' })
+          setProfile({ pseudo: p.pseudo || '', color: p.color || '#ffffff', isMJ: !!p.isMJ })
         }
       } catch {
         /* empty */
@@ -142,12 +144,17 @@ export default function HomePage() {
       <Head>
         <title>CakeJDR</title>
       </Head>
-      <div className="absolute top-2 left-2 z-50 flex gap-2">
-        <Link href="/menu" className="bg-gray-800 text-white px-2 py-1 rounded text-sm">Menu</Link>
-        <GMCharacterSelector onSelect={setPerso} />
-      </div>
-
-      <CharacterSheet perso={perso} onUpdate={setPerso} chatBoxRef={chatBoxRef} />
+      <CharacterSheet
+        perso={perso}
+        onUpdate={setPerso}
+        chatBoxRef={chatBoxRef}
+        headerExtras={(
+          <>
+            <Link href="/menu" className="bg-gray-800 text-white px-2 py-1 rounded text-xs">Menu</Link>
+            {profile.isMJ && <GMCharacterSelector onSelect={setPerso} />}
+          </>
+        )}
+      />
 
       <main className="flex-1 bg-white dark:bg-gray-950 flex flex-col">
         <div className="flex-1 border m-4 bg-gray-50 dark:bg-gray-900 flex flex-col justify-center items-center relative">
@@ -159,16 +166,18 @@ export default function HomePage() {
             onFinish={handlePopupFinish} // 👈 Animation terminée = affiche dans le chat
           />
         </div>
-
         <DiceRoller
           diceType={diceType}
           onChange={setDiceType}
           onRoll={rollDice}
           disabled={diceDisabled}
-        />
+        >
+          <OnlineProfiles />
+        </DiceRoller>
       </main>
 
       <ChatBox chatBoxRef={chatBoxRef} history={history} />
+      <SideNotes />
     </div>
   )
 }

--- a/components/CharacterSheet.tsx
+++ b/components/CharacterSheet.tsx
@@ -9,15 +9,13 @@ import DescriptionPanel from './DescriptionPanel'
 import LevelUpPanel from './LevelUpPanel'
 import ImportExportMenu from './ImportExportMenu'
 import CharacterSheetHeader from './CharacterSheetHeader'
-import NotesPanel from './NotesPanel'
 
 // (ImportExportMenu ici plus tard)
 
 const TABS = [
   { key: 'main', label: 'Statistiques' },
   { key: 'equip', label: 'Équipement' },
-  { key: 'desc', label: 'Description' },
-  { key: 'notes', label: 'Notes' }
+  { key: 'desc', label: 'Description' }
 ]
 
 type Competence = { nom: string, type: string, effets: string, degats?: string }
@@ -29,7 +27,9 @@ type Props = {
   perso: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onUpdate: (perso: any) => void,
-  chatBoxRef?: React.RefObject<HTMLDivElement | null>
+  chatBoxRef?: React.RefObject<HTMLDivElement | null>,
+  creation?: boolean,
+  headerExtras?: React.ReactNode
 }
 
 export const defaultPerso = {
@@ -67,8 +67,8 @@ export const defaultPerso = {
   notes: ''
 }
 
-const CharacterSheet: FC<Props> = ({ perso, onUpdate, chatBoxRef }) => {
-  const [edit, setEdit] = useState(false)
+const CharacterSheet: FC<Props> = ({ perso, onUpdate, chatBoxRef, creation = false, headerExtras }) => {
+  const [edit, setEdit] = useState(creation)
   const [tab, setTab] = useState('main')
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [localPerso, setLocalPerso] = useState<any>(
@@ -156,26 +156,29 @@ const CharacterSheet: FC<Props> = ({ perso, onUpdate, chatBoxRef }) => {
     <aside
       className="bg-gray-900 pt-0 pb-3 px-3 overflow-y-auto text-[15px] text-white relative select-none"
       style={{
-        width: '420px',       // Largeur fixe (cohérent partout)
-        minWidth: '420px',
-        maxWidth: '420px',
+        width: creation ? 'auto' : '420px',
+        minWidth: creation ? '600px' : '420px',
+        maxWidth: creation ? '100%' : '420px',
         boxSizing: 'border-box',
         overflowX: 'hidden'
       }}
     >
 
-      <CharacterSheetHeader
-        edit={edit}
-        onToggleEdit={() => setEdit(true)}
-        onSave={save}
-        tab={tab}
-        setTab={setTab}
-        TABS={TABS}
-      >
-        <ImportExportMenu perso={edit ? localPerso : cFiche} onUpdate={onUpdate} />
-      </CharacterSheetHeader>
+      {!creation && (
+        <CharacterSheetHeader
+          edit={edit}
+          onToggleEdit={() => setEdit(true)}
+          onSave={save}
+          tab={tab}
+          setTab={setTab}
+          TABS={TABS}
+        >
+          {headerExtras}
+          <ImportExportMenu perso={edit ? localPerso : cFiche} onUpdate={onUpdate} />
+        </CharacterSheetHeader>
+      )}
 
-      {tab === 'main' && (
+      {(creation || tab === 'main') && (
         <>
           <StatsPanel
             edit={edit}
@@ -209,8 +212,7 @@ const CharacterSheet: FC<Props> = ({ perso, onUpdate, chatBoxRef }) => {
           />
         </>
       )}
-
-      {tab === 'equip' && (
+      {(creation || tab === 'equip') && (
         <EquipPanel
           edit={edit}
           armes={localPerso.armes}
@@ -234,7 +236,7 @@ const CharacterSheet: FC<Props> = ({ perso, onUpdate, chatBoxRef }) => {
         />
       )}
 
-      {tab === 'desc' && (
+      {(creation || tab === 'desc') && (
         <DescriptionPanel
           edit={edit}
           values={{
@@ -275,13 +277,6 @@ const CharacterSheet: FC<Props> = ({ perso, onUpdate, chatBoxRef }) => {
         />
       )}
 
-      {tab === 'notes' && (
-        <NotesPanel
-          edit={edit}
-          value={localPerso.notes || ''}
-          onChange={txt => handleChange('notes', txt)}
-        />
-      )}
 
       {edit && (
         <button onClick={save} className="mt-3 w-full bg-green-600 text-white px-3 py-1 rounded hover:bg-green-700 text-sm">Sauver</button>

--- a/components/ChatBox.tsx
+++ b/components/ChatBox.tsx
@@ -2,7 +2,6 @@
 import { FC, RefObject, useRef, useState, useEffect } from 'react'
 import SummaryPanel from './SummaryPanel'
 import DiceStats from './DiceStats'
-import OnlineProfiles from './OnlineProfiles'
 
 type Roll = { player: string, dice: number, result: number }
 
@@ -67,7 +66,6 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history }) => {
           </div>
 
           <div className="mt-4 flex items-center">
-            <OnlineProfiles />
             <input
               type="text"
               placeholder="Votre message..."

--- a/components/DiceRoller.tsx
+++ b/components/DiceRoller.tsx
@@ -6,9 +6,10 @@ type Props = {
   onChange: (value: number) => void
   onRoll: () => void
   disabled: boolean
+  children?: React.ReactNode
 }
 
-const DiceRoller: FC<Props> = ({ diceType, onChange, onRoll, disabled }) => (
+const DiceRoller: FC<Props> = ({ diceType, onChange, onRoll, disabled, children }) => (
   <div className="p-4 bg-gray-200 dark:bg-gray-800 flex items-center gap-2">
     <label htmlFor="diceType" className="mr-2 font-semibold">Type de dé :</label>
     <select
@@ -29,6 +30,7 @@ const DiceRoller: FC<Props> = ({ diceType, onChange, onRoll, disabled }) => (
     >
       Lancer
     </button>
+    {children && <div className="ml-4 flex gap-1">{children}</div>}
   </div>
 )
 

--- a/components/DiceStats.tsx
+++ b/components/DiceStats.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 type Roll = { player: string, dice: number, result: number }
 
@@ -20,10 +20,7 @@ function computeStats(history: Roll[]) {
 
 export default function DiceStats({ history }: Props) {
   const [selected, setSelected] = useState<string>('all')
-  const [stats, setStats] = useState(() => computeStats(history))
-  useEffect(() => {
-    setStats(computeStats(history))
-  }, [history])
+  const stats = computeStats(history)
   const players = Object.keys(stats)
 
   const renderRow = (player: string) => {

--- a/components/GMCharacterSelector.tsx
+++ b/components/GMCharacterSelector.tsx
@@ -15,6 +15,7 @@ export default function GMCharacterSelector({ onSelect }: Props) {
   const [chars, setChars] = useState<Character[]>([])
   const [open, setOpen] = useState(false)
   const [selectedId, setSelectedId] = useState<number | null>(null)
+  const selectedName = chars.find(c => c.id === selectedId)?.name || ''
 
   // Chargement initial + écoute des modifications
   useEffect(() => {
@@ -62,11 +63,12 @@ export default function GMCharacterSelector({ onSelect }: Props) {
   }
 
   return (
-    <div className="relative inline-block ml-2">
+    <div className="relative inline-flex items-center ml-2 text-white bg-gray-800 rounded px-2 py-1 gap-2">
       <button
         onClick={() => { refreshList(); setOpen(o => !o) }}
-        className="px-2 py-1 bg-gray-800 text-white rounded text-xs"
-      >Changer de perso</button>
+        className="px-2 py-1 bg-gray-700 text-white rounded text-xs"
+      >Changer</button>
+      {selectedName && <span className="text-sm">{selectedName}</span>}
       {open && (
         <div className="absolute right-0 mt-2 bg-gray-900 text-white rounded shadow-xl p-2 z-50">
           {chars.length === 0 && <div className="px-2">Aucun perso</div>}

--- a/components/MenuAccueil.tsx
+++ b/components/MenuAccueil.tsx
@@ -186,7 +186,7 @@ const handleProfileChange = (field: string) => (e: React.ChangeEvent<HTMLInputEl
               onChange={handleProfileChange('isMJ')}
               className="form-checkbox"
             />
-            <label htmlFor="mjCheck" className="font-semibold">Je suis MJ</label>
+            <label htmlFor="mjCheck" className="font-semibold">MJ</label>
           </div>
           <button
             onClick={handleSaveProfile}
@@ -258,7 +258,7 @@ const handleProfileChange = (field: string) => (e: React.ChangeEvent<HTMLInputEl
     {modalOpen && (
       <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
         <div className="bg-gray-800 p-4 rounded overflow-y-auto max-h-full">
-          <CharacterSheet perso={draftChar} onUpdate={setDraftChar} />
+          <CharacterSheet perso={draftChar} onUpdate={setDraftChar} creation />
           <div className="flex justify-end gap-2 mt-2">
             <button
               onClick={() => setModalOpen(false)}

--- a/components/OnlineProfiles.tsx
+++ b/components/OnlineProfiles.tsx
@@ -31,7 +31,7 @@ export default function OnlineProfiles() {
   if (entries.length === 0) return null
 
   return (
-    <div className="flex gap-1 mr-2">
+    <div className="flex gap-1 flex-row-reverse">
       {entries.map(([id, p]) => (
         <div
           key={id}

--- a/components/SideNotes.tsx
+++ b/components/SideNotes.tsx
@@ -1,0 +1,46 @@
+'use client'
+import { useState, useEffect } from 'react'
+
+const STORAGE_KEY = 'jdr_side_notes'
+
+export default function SideNotes() {
+  const [open, setOpen] = useState(false)
+  const [notes, setNotes] = useState('')
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved) setNotes(saved)
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, notes)
+  }, [notes])
+
+  return (
+    <div className="fixed top-1/2 left-0 -translate-y-1/2 z-50">
+      {open ? (
+        <div className="relative bg-gray-900 text-white p-2 rounded-r w-64">
+          <textarea
+            className="w-full h-40 bg-gray-800 p-1 text-sm rounded"
+            value={notes}
+            onChange={e => setNotes(e.target.value)}
+          />
+          <button
+            className="absolute -right-4 top-1/2 -translate-y-1/2 bg-gray-800 text-white px-1 rounded-r"
+            onClick={() => setOpen(false)}
+          >
+            ◀
+          </button>
+        </div>
+      ) : (
+        <button
+          className="bg-gray-800 text-white px-1 py-0.5 rounded-r"
+          onClick={() => setOpen(true)}
+          title="Notes"
+        >
+          ▶
+        </button>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- show selected character name in header and restrict switching to MJ
- move online profiles next to the dice roller
- remove notes tab and add side notes drawer
- allow extra header controls for character sheet
- expose online profiles horizontally in reverse order

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b92b00aa4832e87ff14a432521862