### PR TITLE
Fix redirects to home page

### DIFF
--- a/app/menu/menuacceuil/page.tsx
+++ b/app/menu/menuacceuil/page.tsx
@@ -1,0 +1,4 @@
+import MenuAccueil from '@/components/MenuAccueil'
+export default function MenuAccueilPage() {
+  return <MenuAccueil />
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -65,7 +65,7 @@ export default function HomePage() {
     if (typeof window === 'undefined') return
     if (!sessionStorage.getItem('visitedMenu')) {
       sessionStorage.setItem('visitedMenu', 'true')
-      router.push('/menu')
+      router.push('/menu/menuacceuil')
     }
   }, [])
 
@@ -189,7 +189,7 @@ export default function HomePage() {
         chatBoxRef={chatBoxRef}
       >
         <Link
-          href="/menu"
+          href="/menu/menuacceuil"
           className="bg-gray-800 hover:bg-gray-900 text-white px-2 py-1 rounded text-xs"
           style={{ minWidth: 70 }}
         >

--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -72,7 +72,7 @@ export default function Login({ onLogin }: Props) {
       setError(null)
       window.dispatchEvent(new Event('jdr_profile_change'))
       onLogin(trimmedPseudo)
-      router.push('/menu')
+      router.push('/menu/menuacceuil')
       return
     }
 
@@ -96,7 +96,7 @@ export default function Login({ onLogin }: Props) {
     window.dispatchEvent(new Event('jdr_profile_change'))
     setError(null)
     onLogin(trimmedPseudo)
-    router.push('/menu')
+    router.push('/menu/menuacceuil')
   }
 
   /* ---------- UI ---------- */


### PR DESCRIPTION
## Summary
- add explicit `/menu/menuacceuil` route using `MenuAccueil` component
- redirect to new page after login and initial visit
- update `Menu` link in character sheet to go to `/menu/menuacceuil`

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_687c06996588832e9ffeba50b39ad0d6