### PR TITLE
Refactor: split large components

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,10 @@
 'use client'
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { useEffect, useRef, useState } from 'react'
 import { useRouter, usePathname } from 'next/navigation'
 // Déplacement fichier pour organisation
-import CharacterSheet, { defaultPerso } from '@/components/character/CharacterSheet'
+import CharacterSheet, { defaultPerso } from '@/components/sheet/CharacterSheet'
 // Déplacement fichier pour organisation
 import DiceRoller from '@/components/dice/DiceRoller'
 // Déplacement fichier pour organisation
@@ -82,7 +83,7 @@ export default function HomePage() {
   // Présence en ligne
   useEffect(() => {
     if (!user) return
-    const id = localStorage.getItem('jdr_profile_id') || String(Date.now())
+    const id = localStorage.getItem('jdr_profile_id') || crypto.randomUUID()
     localStorage.setItem('jdr_profile_id', id)
     const updateOnline = () => {
       try {
@@ -155,7 +156,7 @@ export default function HomePage() {
     // Charger le perso sélectionné
     const selectedId = localStorage.getItem('selectedCharacterId')
     if (selectedId && chars.length) {
-      const found = chars.find(c => c.id?.toString() === selectedId)
+      const found = chars.find((c: any) => c.id?.toString() === selectedId)
       if (found) {
         setPerso(found)
       } else {

--- a/components/character/ImportExportMenu.tsx
+++ b/components/character/ImportExportMenu.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { FC, useRef, useState } from 'react'
-import { defaultPerso } from './CharacterSheet' // <-- AJOUT
+import { defaultPerso } from '../sheet/CharacterSheet' // <-- AJOUT
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Props = {
@@ -57,7 +57,7 @@ const ImportExportMenu: FC<Props> = ({ perso, onUpdate }) => {
         const data = JSON.parse(txt)
         if (!data || typeof data !== "object") throw new Error()
         onUpdate(data)
-        addToList({ ...data, id: data.id || Date.now() })
+        addToList({ ...data, id: data.id || crypto.randomUUID() })
         alert('Fiche importée avec succès !')
       } catch {
         alert('Erreur lors de l\'import : le fichier doit être un fichier texte au format JSON.')
@@ -83,7 +83,7 @@ const ImportExportMenu: FC<Props> = ({ perso, onUpdate }) => {
         const obj = JSON.parse(data)
         if (!obj || typeof obj !== "object") throw new Error()
         onUpdate(obj)
-        addToList({ ...obj, id: obj.id || Date.now() })
+        addToList({ ...obj, id: obj.id || crypto.randomUUID() })
         alert('Fiche chargée depuis la sauvegarde locale !')
       } catch {
         alert('Erreur lors du chargement local.')

--- a/components/menu/CharacterList.tsx
+++ b/components/menu/CharacterList.tsx
@@ -1,0 +1,101 @@
+import { FC, RefObject } from 'react'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export type Character = {
+  id: string | number
+  nom: string
+  owner: string
+  [key: string]: any
+}
+
+interface Props {
+  filtered: Character[]
+  selectedIdx: number | null
+  onSelect: (idx: number) => void
+  onEdit: (idx: number) => void
+  onDelete: (idx: number) => void
+  onNew: () => void
+  onImportClick: () => void
+  onExport: () => void
+  fileInputRef: RefObject<HTMLInputElement | null>
+  onImportFile: (e: React.ChangeEvent<HTMLInputElement>) => void
+}
+
+const CharacterList: FC<Props> = ({
+  filtered,
+  selectedIdx,
+  onSelect,
+  onEdit,
+  onDelete,
+  onNew,
+  onImportClick,
+  onExport,
+  fileInputRef,
+  onImportFile,
+}) => (
+  <section className="bg-gray-800 bg-opacity-40 rounded-lg p-6 flex-grow" style={{ overflow: 'hidden' }}>
+    <h2 className="text-2xl font-bold mb-4 select-none">Vos fiches de personnage</h2>
+    {filtered.length === 0 ? (
+      <p>Aucune fiche sauvegardée pour ce profil.</p>
+    ) : (
+      <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {filtered.map((ch, idx) => (
+          <li
+            key={ch.id}
+            className={`bg-gray-700 rounded p-4 flex flex-col justify-between cursor-pointer ${
+              selectedIdx !== null && filtered[selectedIdx]?.id === ch.id
+                ? 'ring-4 ring-green-400'
+                : 'ring-0'
+            } transition-ring duration-300`}
+            onClick={() => onSelect(idx)}
+            title={`${ch.nom} - Niveau ${ch.niveau || '?'}`}
+          >
+            <span className="font-semibold text-lg mb-2 truncate">{ch.nom}</span>
+            <div className="flex gap-2">
+              <button
+                onClick={e => {
+                  e.stopPropagation()
+                  onEdit(idx)
+                }}
+                className="flex-1 bg-yellow-600 hover:bg-yellow-700 text-white px-2 py-1 rounded text-sm"
+                title="Modifier la fiche"
+              >
+                Modifier
+              </button>
+              <button
+                onClick={e => {
+                  e.stopPropagation()
+                  onDelete(idx)
+                }}
+                className="flex-1 bg-red-600 hover:bg-red-700 text-white px-2 py-1 rounded text-sm"
+                title="Supprimer la fiche"
+              >
+                Supprimer
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    )}
+    <div className="mt-6 flex gap-4">
+      <button onClick={onNew} className="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-2 rounded shadow">
+        Nouvelle fiche complète
+      </button>
+      <button onClick={onImportClick} className="bg-gray-600 hover:bg-gray-700 text-white font-semibold px-6 py-2 rounded shadow">
+        Importer
+      </button>
+      <button
+        onClick={onExport}
+        disabled={selectedIdx === null}
+        className={`font-semibold px-6 py-2 rounded shadow ${
+          selectedIdx === null ? 'bg-gray-400 cursor-not-allowed' : 'bg-gray-600 hover:bg-gray-700 text-white'
+        }`}
+      >
+        Exporter
+      </button>
+      <input type="file" accept="text/plain" ref={fileInputRef} onChange={onImportFile} className="hidden" />
+    </div>
+  </section>
+)
+
+export default CharacterList

--- a/components/menu/CharacterModal.tsx
+++ b/components/menu/CharacterModal.tsx
@@ -1,0 +1,29 @@
+"use client"
+import { FC } from 'react'
+import CharacterSheet from '../sheet/CharacterSheet'
+import { Character } from './CharacterList'
+
+interface Props {
+  open: boolean
+  character: Character
+  onUpdate: (c: Character) => void
+  onSave: () => void
+  onClose: () => void
+}
+
+const CharacterModal: FC<Props> = ({ open, character, onUpdate, onSave, onClose }) => {
+  if (!open) return null
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-6" role="dialog" aria-modal="true">
+      <div className="relative bg-gray-900 rounded-xl shadow-lg flex flex-col w-[95vw] max-w-[1400px] p-6" style={{ height: '95vh' }}>
+        <CharacterSheet perso={character} onUpdate={onUpdate} creation={false} key={character.id} />
+        <div className="border-t border-gray-700 mt-4 pt-4 flex justify-end gap-4">
+          <button onClick={onClose} className="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded font-semibold">Annuler</button>
+          <button onClick={onSave} className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded font-semibold">Sauvegarder</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CharacterModal

--- a/components/menu/MenuHeader.tsx
+++ b/components/menu/MenuHeader.tsx
@@ -1,0 +1,51 @@
+"use client"
+import { FC } from 'react'
+import Link from 'next/link'
+import ProfileColorPicker from './ProfileColorPicker'
+
+export type User = { pseudo: string; isMJ: boolean; color: string }
+
+interface Props {
+  user: User | null
+  onLogout: () => void
+  onToggleMJ: () => void
+  onChangeColor: (c: string) => void
+}
+
+const MenuHeader: FC<Props> = ({ user, onLogout, onToggleMJ, onChangeColor }) => (
+  <header className="flex items-center justify-between mb-8 select-none">
+    <h1 className="text-4xl font-extrabold tracking-wide flex items-center gap-3">
+      CAKE JDR <span role="img" aria-label="gateau">🎂</span>
+    </h1>
+    {user && (
+      <div className="flex items-center gap-4">
+        <Link
+          href="/"
+          className="bg-green-600 hover:bg-green-700 px-3 py-1 rounded font-semibold text-sm"
+          title="Revenir à la partie"
+        >
+          Table de jeux
+        </Link>
+        <button
+          onClick={onLogout}
+          className="bg-red-600 hover:bg-red-700 px-3 py-1 rounded font-semibold text-sm"
+          title="Se déconnecter"
+        >
+          Déconnexion
+        </button>
+        <button
+          className={`px-3 py-1 rounded font-semibold text-sm text-white ${
+            user.isMJ ? 'bg-purple-700 hover:bg-purple-800' : 'bg-gray-600 hover:bg-gray-700'
+          }`}
+          onClick={onToggleMJ}
+          title={user.isMJ ? 'Désactiver le mode MJ' : 'Activer le mode MJ'}
+        >
+          {user.isMJ ? 'Mode MJ activé' : 'Activer le mode MJ'}
+        </button>
+        <ProfileColorPicker color={user.color} onChange={onChangeColor} />
+      </div>
+    )}
+  </header>
+)
+
+export default MenuHeader

--- a/components/menu/ProfileColorPicker.tsx
+++ b/components/menu/ProfileColorPicker.tsx
@@ -1,0 +1,36 @@
+"use client"
+import { FC } from 'react'
+
+const COLORS = [
+  '#e11d48','#1d4ed8','#16a34a','#f59e0b','#d946ef',
+  '#0d9488','#f97316','#a3a3a3','#ffffff','#000000'
+]
+
+interface Props {
+  color: string
+  onChange: (c: string) => void
+}
+
+const ProfileColorPicker: FC<Props> = ({ color, onChange }) => (
+  <div className="flex items-center gap-1">
+    {COLORS.map(c => (
+      <button
+        key={c}
+        onClick={() => onChange(c)}
+        className={`w-6 h-6 rounded-full border-2 ${
+          color === c ? 'border-white scale-110' : 'border-gray-400'
+        }`}
+        style={{ backgroundColor: c }}
+        aria-label={c}
+      />
+    ))}
+    <input
+      type="color"
+      value={color}
+      onChange={e => onChange(e.target.value)}
+      className="w-6 h-6 rounded border-2 border-gray-400 cursor-pointer p-0"
+    />
+  </div>
+)
+
+export default ProfileColorPicker

--- a/components/misc/GMCharacterSelector.tsx
+++ b/components/misc/GMCharacterSelector.tsx
@@ -1,4 +1,5 @@
 'use client'
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { useEffect, useState, useRef } from 'react'
 import { User2 } from 'lucide-react'
@@ -9,9 +10,11 @@ type Character = { id: number, name?: string, nom?: string }
 
 type Props = {
   onSelect: (char: any) => void
+  buttonLabel?: string
+  className?: string
 }
 
-export default function GMCharacterSelector({ onSelect }: Props) {
+export default function GMCharacterSelector({ onSelect, buttonLabel = 'Personnage', className = 'flex items-center gap-1 px-3 py-1 rounded bg-purple-700 hover:bg-purple-800 text-white text-xs border border-purple-500' }: Props) {
   const [chars, setChars] = useState<Character[]>([])
   const [open, setOpen] = useState(false)
   const [selectedId, setSelectedId] = useState<number | null>(null)
@@ -69,14 +72,14 @@ export default function GMCharacterSelector({ onSelect }: Props) {
     <div ref={dropdownRef} className="relative">
       <button
         onClick={() => setOpen(o => !o)}
-        className="flex items-center gap-1 px-3 py-1 rounded bg-purple-700 hover:bg-purple-800 text-white text-xs border border-purple-500"
+        className={className}
         style={{ minWidth: 0 }}
         tabIndex={0}
         aria-haspopup="listbox"
         aria-expanded={open}
       >
         <User2 size={16} className="mr-1" />
-        Personnage
+        {buttonLabel}
       </button>
       {open && (
         <div className="absolute left-0 mt-1 w-48 bg-white dark:bg-gray-900 text-gray-900 dark:text-white rounded shadow-lg border border-purple-500 z-50 py-1">

--- a/components/sheet/CharacterSheet.tsx
+++ b/components/sheet/CharacterSheet.tsx
@@ -2,12 +2,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { FC, useState, useEffect } from 'react'
-import StatsPanel from './StatsPanel'
-import CompetencesPanel from './CompetencesPanel'
-import EquipPanel from './EquipPanel'
-import DescriptionPanel from './DescriptionPanel'
-import LevelUpPanel from './LevelUpPanel'
-import CharacterSheetHeader from './CharacterSheetHeader'
+import StatsTab from './StatsTab'
+import EquipTab from './EquipTab'
+import DescriptionPanel from '../character/DescriptionPanel'
+import CharacterSheetHeader from '../character/CharacterSheetHeader'
 
 const TABS = [
   { key: 'main', label: 'Statistiques' },
@@ -15,9 +13,6 @@ const TABS = [
   { key: 'desc', label: 'Description' }
 ]
 
-type Competence = { nom: string, type: string, effets: string, degats?: string }
-type Objet = { nom: string, quantite: number }
-type CustomField = { label: string, value: string }
 
 type Props = {
   perso: any, // Fiche perso initiale
@@ -197,59 +192,26 @@ const CharacterSheet: FC<Props> = ({
       )}
 
       {(creation || tab === 'main') && (
-        <>
-          <StatsPanel
-            edit={edit}
-            perso={localPerso}
-            onChange={handleChange}
-          />
-          <CompetencesPanel
-            edit={edit}
-            competences={localPerso.competences || []}
-            onAdd={(comp: Competence) =>
-              setLocalPerso({
-                ...localPerso,
-                competences: [...(localPerso.competences || []), comp]
-              })
-            }
-            onDelete={(idx: number) =>
-              setLocalPerso({
-                ...localPerso,
-                competences: (localPerso.competences || []).filter((_: unknown, i: number) => i !== idx)
-              })
-            }
-          />
-          <LevelUpPanel
-            dice={dice}
-            setDice={setDice}
-            onLevelUp={handleLevelUp}
-            processing={processing}
-            lastStat={lastStat}
-            lastGain={lastGain}
-            animKey={animKey}
-          />
-        </>
+        <StatsTab
+          edit={edit}
+          perso={localPerso}
+          onChange={handleChange}
+          setLocalPerso={setLocalPerso}
+          localPerso={localPerso}
+          dice={dice}
+          setDice={setDice}
+          onLevelUp={handleLevelUp}
+          processing={processing}
+          lastStat={lastStat}
+          lastGain={lastGain}
+          animKey={animKey}
+        />
       )}
       {(creation || tab === 'equip') && (
-        <EquipPanel
+        <EquipTab
           edit={edit}
-          armes={localPerso.armes}
-          armure={localPerso.armure}
-          degats_armes={localPerso.degats_armes}
-          modif_armure={localPerso.modif_armure}
-          objets={localPerso.objets || []}
-          onAddObj={(obj: Objet) =>
-            setLocalPerso({
-              ...localPerso,
-              objets: [...(localPerso.objets || []), obj]
-            })
-          }
-          onDelObj={(idx: number) =>
-            setLocalPerso({
-              ...localPerso,
-              objets: (localPerso.objets || []).filter((_: unknown, i: number) => i !== idx)
-            })
-          }
+          localPerso={localPerso}
+          setLocalPerso={setLocalPerso}
           onChange={handleChange}
         />
       )}

--- a/components/sheet/EquipTab.tsx
+++ b/components/sheet/EquipTab.tsx
@@ -1,0 +1,37 @@
+'use client'
+import { FC } from 'react'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import EquipPanel from '../character/EquipPanel'
+
+interface Props {
+  edit: boolean
+  localPerso: any
+  setLocalPerso: (p: any) => void
+  onChange: (field: string, value: any) => void
+}
+
+const EquipTab: FC<Props> = ({ edit, localPerso, setLocalPerso, onChange }) => (
+  <EquipPanel
+    edit={edit}
+    armes={localPerso.armes}
+    armure={localPerso.armure}
+    degats_armes={localPerso.degats_armes}
+    modif_armure={localPerso.modif_armure}
+    objets={localPerso.objets || []}
+    onAddObj={(obj) =>
+      setLocalPerso({
+        ...localPerso,
+        objets: [...(localPerso.objets || []), obj],
+      })
+    }
+    onDelObj={(idx) =>
+      setLocalPerso({
+        ...localPerso,
+        objets: (localPerso.objets || []).filter((_: any, i: number) => i !== idx),
+      })
+    }
+    onChange={onChange}
+  />
+)
+
+export default EquipTab

--- a/components/sheet/StatsTab.tsx
+++ b/components/sheet/StatsTab.tsx
@@ -1,0 +1,67 @@
+'use client'
+import { FC } from 'react'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import StatsPanel from '../character/StatsPanel'
+import CompetencesPanel from '../character/CompetencesPanel'
+import LevelUpPanel from '../character/LevelUpPanel'
+
+interface Props {
+  edit: boolean
+  perso: any
+  onChange: (field: string, value: any) => void
+  setLocalPerso: (p: any) => void
+  localPerso: any
+  dice: string
+  setDice: (d: string) => void
+  onLevelUp: () => Promise<void>
+  processing: boolean
+  lastStat: string | null
+  lastGain: number | null
+  animKey: number
+}
+
+const StatsTab: FC<Props> = ({
+  edit,
+  perso,
+  onChange,
+  setLocalPerso,
+  localPerso,
+  dice,
+  setDice,
+  onLevelUp,
+  processing,
+  lastStat,
+  lastGain,
+  animKey,
+}) => (
+  <>
+    <StatsPanel edit={edit} perso={perso} onChange={onChange} />
+    <CompetencesPanel
+      edit={edit}
+      competences={localPerso.competences || []}
+      onAdd={(comp) =>
+        setLocalPerso({
+          ...localPerso,
+          competences: [...(localPerso.competences || []), comp],
+        })
+      }
+        onDelete={(idx) =>
+          setLocalPerso({
+            ...localPerso,
+            competences: (localPerso.competences || []).filter((_: any, i: number) => i !== idx),
+          })
+      }
+    />
+    <LevelUpPanel
+      dice={dice}
+      setDice={setDice}
+      onLevelUp={onLevelUp}
+      processing={processing}
+      lastStat={lastStat}
+      lastGain={lastGain}
+      animKey={animKey}
+    />
+  </>
+)
+
+export default StatsTab


### PR DESCRIPTION
## Summary
- split `MenuAccueil` into subcomponents
- move `CharacterSheet` under `sheet/` folder
- add `StatsTab` and `EquipTab` for clarity
- add color picker and modal components
- generate ids with `crypto.randomUUID`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687cc514ed74832ebb5016a1cea10258