### PR TITLE
Fix login flow and UI polish

### DIFF
--- a/app/menu/page.tsx
+++ b/app/menu/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
 import Login from '@/components/login/Login'
 import RpgBackground from '@/components/ui/RpgBackground'
@@ -13,6 +13,15 @@ export default function MenuPage() {
   const handleLogin = () => {
     setLeaving(true)
   }
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem('jdr_profile')
+      if (!raw) return
+      const prof = JSON.parse(raw)
+      if (prof.loggedIn) handleLogin()
+    } catch {}
+  }, [])
 
   return (
     <motion.div

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -117,7 +117,7 @@ export default function HomePage() {
       const saved = localStorage.getItem('jdr_profile')
       if (saved) {
         const p = JSON.parse(saved)
-        if (p.pseudo) {
+        if (p.pseudo && p.loggedIn) {
           setUser(p.pseudo)
           setProfile({ pseudo: p.pseudo, color: p.color || '#ffffff', isMJ: !!p.isMJ })
         }
@@ -132,7 +132,9 @@ export default function HomePage() {
         const saved = localStorage.getItem('jdr_profile')
         if (saved) {
           const p = JSON.parse(saved)
-          setProfile({ pseudo: p.pseudo || '', color: p.color || '#ffffff', isMJ: !!p.isMJ })
+          if (p.loggedIn) {
+            setProfile({ pseudo: p.pseudo || '', color: p.color || '#ffffff', isMJ: !!p.isMJ })
+          }
         }
       } catch {}
     }
@@ -201,6 +203,7 @@ export default function HomePage() {
         perso={perso}
         onUpdate={setPerso}
         chatBoxRef={chatBoxRef}
+        logoOnly
       >
         <Link
            href="/menu-accueil"

--- a/components/character/CharacterSheetHeader.tsx
+++ b/components/character/CharacterSheetHeader.tsx
@@ -11,7 +11,8 @@ type Props = {
   tab: string,
   setTab: (tabKey: string) => void,
   TABS: Tab[],
-  children?: React.ReactNode
+  children?: React.ReactNode,
+  logoOnly?: boolean
 }
 
 const CharacterSheetHeader: FC<Props> = ({
@@ -21,7 +22,8 @@ const CharacterSheetHeader: FC<Props> = ({
   tab,
   setTab,
   TABS,
-  children
+  children,
+  logoOnly = false
 }) => {
   const router = useRouter();
 
@@ -39,7 +41,7 @@ const CharacterSheetHeader: FC<Props> = ({
       <div className="flex justify-between items-center">
         {/* --- TOUS LES BOUTONS À GAUCHE --- */}
         <div className="flex items-center gap-2">
-          <CakeLogo className="mr-2" />
+          <CakeLogo className="mr-2" showText={!logoOnly} />
           {childrenArray.map((child, i) => (
             <span key={i} className="flex items-center">{child}</span>
           ))}

--- a/components/login/Login.tsx
+++ b/components/login/Login.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import CakeLogo from '../ui/CakeLogo'
 const PROFILE_KEY = 'jdr_profile'
 
 export default function Login({ onLogin }:{ onLogin:(pseudo:string)=>void }) {
@@ -10,6 +9,7 @@ export default function Login({ onLogin }:{ onLogin:(pseudo:string)=>void }) {
   /* ----------------------------------------------------------------------- */
   const [pseudo, setPseudo] = useState('')
   const [error,  setError]  = useState<string | null>(null)
+  const [registerMode, setRegisterMode] = useState(false)
 
   /* ----------------------------------------------------------------------- */
   /*  Pré‑remplissage si profil déjà présent                                 */
@@ -33,28 +33,28 @@ export default function Login({ onLogin }:{ onLogin:(pseudo:string)=>void }) {
 
     const saved = JSON.parse(localStorage.getItem(PROFILE_KEY) || '{}')
 
-    /* ---------- Connexion ---------- */
-    if (saved.pseudo) {
-      if (saved.pseudo !== trimmedPseudo) { setError('Pseudo inconnu, créez un compte'); return }
+    if (registerMode) {
+      /* ---------- Création ---------- */
+      const newProf = {
+        pseudo: trimmedPseudo,
+        color: '#1d4ed8',
+        isMJ: false,
+        loggedIn: true
+      }
+      localStorage.setItem(PROFILE_KEY, JSON.stringify(newProf))
+      window.dispatchEvent(new Event('jdr_profile_change'))
+      setError(null)
+      onLogin(trimmedPseudo)
+    } else {
+      /* ---------- Connexion ---------- */
+      if (!saved.pseudo) { setError('Aucun compte, créez-en un'); return }
+      if (saved.pseudo !== trimmedPseudo) { setError('Pseudo inconnu'); return }
 
       localStorage.setItem(PROFILE_KEY, JSON.stringify({ ...saved, loggedIn: true }))
       window.dispatchEvent(new Event('jdr_profile_change'))
       setError(null)
       onLogin(trimmedPseudo)
-      return
     }
-
-    /* ---------- Création ---------- */
-    const newProf = {
-      pseudo: trimmedPseudo,
-      color: '#1d4ed8',
-      isMJ: false,
-      loggedIn: true
-    }
-    localStorage.setItem(PROFILE_KEY, JSON.stringify(newProf))
-    window.dispatchEvent(new Event('jdr_profile_change'))
-    setError(null)
-    onLogin(trimmedPseudo)
   }
 
   /* ----------------------------------------------------------------------- */
@@ -65,9 +65,6 @@ export default function Login({ onLogin }:{ onLogin:(pseudo:string)=>void }) {
       onSubmit={handleSubmit}
       className="bg-gray-800 p-6 rounded-lg flex flex-col gap-4 w-72 shadow-lg"
     >
-      <div className="flex justify-center">
-        <CakeLogo />
-      </div>
 
       {error && <p className="text-red-400 text-sm">{error}</p>}
 
@@ -83,6 +80,13 @@ export default function Login({ onLogin }:{ onLogin:(pseudo:string)=>void }) {
         className="bg-blue-600 hover:bg-blue-700 text-white py-2 rounded font-semibold"
       >
         Valider
+      </button>
+      <button
+        type="button"
+        onClick={() => { setRegisterMode(m => !m); setError(null) }}
+        className="text-sm text-blue-300 hover:underline self-center"
+      >
+        {registerMode ? 'Déjà inscrit ?' : 'Pas encore de compte ? S\’inscrire'}
       </button>
     </form>
   )

--- a/components/menu/MenuAccueil.tsx
+++ b/components/menu/MenuAccueil.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { useState, useEffect, useRef } from 'react'
+import { useRouter } from 'next/navigation'
 import Login from '../login/Login'
 import { defaultPerso } from '../sheet/CharacterSheet'
 import MenuHeader from './MenuHeader'
@@ -25,6 +26,7 @@ type Character = {
 /*  Composant Menu Accueil                                                   */
 /* ------------------------------------------------------------------------- */
 export default function MenuAccueil() {
+  const router = useRouter()
   const [user, setUser] = useState<{ pseudo:string; isMJ:boolean; color:string } | null>(null)
   const [characters, setCharacters]   = useState<Character[]>([])
   const [selectedIdx, setSelectedIdx] = useState<number | null>(null)
@@ -43,7 +45,7 @@ export default function MenuAccueil() {
       const raw = localStorage.getItem(PROFILE_KEY)
       if (raw) {
         const prof = JSON.parse(raw)
-        if (prof.pseudo) {
+        if (prof.pseudo && prof.loggedIn) {
           setUser({ pseudo: prof.pseudo, isMJ: !!prof.isMJ, color: prof.color || '#1d4ed8' })
         }
       }
@@ -61,7 +63,7 @@ export default function MenuAccueil() {
         const raw = localStorage.getItem(PROFILE_KEY)
         if (!raw) { setUser(null); return }
         const prof = JSON.parse(raw)
-        if (prof.pseudo) {
+        if (prof.pseudo && prof.loggedIn) {
           setUser({ pseudo: prof.pseudo, isMJ: !!prof.isMJ, color: prof.color || '#1d4ed8' })
         } else setUser(null)
       } catch { setUser(null) }
@@ -98,6 +100,7 @@ export default function MenuAccueil() {
     } catch {}
     setUser(null)
     setSelectedIdx(null)
+    router.push('/menu')
   }
 
   /* ----------------------------------------------------------------------- */

--- a/components/misc/GMCharacterSelector.tsx
+++ b/components/misc/GMCharacterSelector.tsx
@@ -88,7 +88,7 @@ export default function GMCharacterSelector({ onSelect, buttonLabel = 'Personnag
           )}
           {chars.map((c, idx) => (
             <button
-              key={c.id}
+              key={`${c.id}-${idx}`}
               onClick={() => handleSelect(c.id)}
               className={`block w-full text-left px-4 py-2 text-sm
                 ${selectedId === c.id ? 'bg-purple-100 dark:bg-purple-900 font-semibold' : 'hover:bg-purple-50 dark:hover:bg-purple-800'}`}

--- a/components/sheet/CharacterSheet.tsx
+++ b/components/sheet/CharacterSheet.tsx
@@ -21,6 +21,7 @@ type Props = {
   creation?: boolean,
   children?: React.ReactNode,
   allCharacters?: any[], // facultatif, si tu veux passer la liste complète
+  logoOnly?: boolean
 }
 
 export const defaultPerso = {
@@ -69,7 +70,8 @@ const CharacterSheet: FC<Props> = ({
   chatBoxRef,
   creation = false,
   children,
-  allCharacters = []
+  allCharacters = [],
+  logoOnly = false
 }) => {
   const [edit, setEdit] = useState(creation)
   const [tab, setTab] = useState('main')
@@ -186,6 +188,7 @@ const CharacterSheet: FC<Props> = ({
           tab={tab}
           setTab={setTab}
           TABS={TABS}
+          logoOnly={logoOnly}
         >
           {children}
         </CharacterSheetHeader>

--- a/components/ui/CakeLogo.tsx
+++ b/components/ui/CakeLogo.tsx
@@ -2,11 +2,13 @@
 import { Cake } from 'lucide-react'
 import React from 'react'
 
-export default function CakeLogo({ className = '' }: { className?: string }) {
+export default function CakeLogo({ className = '', showText = true }: { className?: string, showText?: boolean }) {
   return (
     <span className={`inline-flex items-center gap-2 ${className}`}>
       <Cake className="w-8 h-8 text-pink-400" />
-      <span className="text-white font-extrabold text-3xl drop-shadow">Cake JDR</span>
+      {showText && (
+        <span className="text-white font-extrabold text-3xl drop-shadow">Cake JDR</span>
+      )}
     </span>
   )
 }

--- a/components/ui/RpgBackground.tsx
+++ b/components/ui/RpgBackground.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 export default function RpgBackground() {
   return (
     <div
-      className="fixed inset-0 -z-10 bg-gradient-to-br from-purple-950 via-indigo-950 to-blue-950"
+      className="fixed inset-0 -z-10 bg-gradient-to-br from-gray-900 via-gray-800 to-black"
       style={{
         backgroundImage:
           'radial-gradient(circle,rgba(255,255,255,0.07) 1px,transparent 1px)',


### PR DESCRIPTION
## Summary
- implement account creation toggle and remove extra logo
- only hydrate user when `loggedIn` is true
- auto-login to menu-accueil when already logged in
- push `/menu` on logout and keep logo only on table header
- polish RPG background and fix duplicate keys

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687cd3d1c27c832ea44c340fa4509262