### PR TITLE
Enhance UI icons and persist character selection

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -218,19 +218,11 @@ export default function HomePage() {
           allCharacters={characters}
           logoOnly
         >
-          <Link
-            href="/menu-accueil"
-            className="bg-gray-800 hover:bg-gray-900 text-white px-2 py-1 rounded text-xs"
-            style={{ minWidth: 70 }}
-          >
-            Menu
-          </Link>
           <ImportExportMenu perso={perso} onUpdate={handleUpdatePerso} />
           {profile.isMJ && (
             <span className="ml-2">
               <GMCharacterSelector
                 onSelect={handleUpdatePerso}
-                buttonLabel="Personnage"
                 className="bg-purple-700 hover:bg-purple-800 text-white px-2 py-1 rounded text-xs border border-purple-500"
               />
             </span>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -223,7 +223,7 @@ export default function HomePage() {
             <span className="ml-2">
               <GMCharacterSelector
                 onSelect={handleUpdatePerso}
-                className="bg-purple-700 hover:bg-purple-800 text-white px-2 py-1 rounded text-xs border border-purple-500"
+                className="bg-gray-800 hover:bg-gray-700 text-white p-2 rounded shadow"
               />
             </span>
           )}

--- a/components/canvas/InteractiveCanvas.tsx
+++ b/components/canvas/InteractiveCanvas.tsx
@@ -409,7 +409,9 @@ export default function InteractiveCanvas() {
           />
         )}
 
-        <p className="absolute bottom-4 left-5 text-xs text-white/70 z-10">Glisse une image ici</p>
+        {images.length === 0 && (
+          <p className="absolute bottom-4 left-5 text-xs text-white/70 z-10">Glisse une image ici</p>
+        )}
       </div>
     </div>
   )

--- a/components/character/CharacterSheetHeader.tsx
+++ b/components/character/CharacterSheetHeader.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import CakeLogo from '../ui/CakeLogo'
 
 type Tab = { key: string, label: string }
@@ -46,7 +47,12 @@ const CharacterSheetHeader: FC<Props> = ({
     >
       <div className="flex justify-between items-center">
         <div className="flex items-center gap-2">
-          <CakeLogo className="mr-2" showText={!logoOnly} />
+          <Link
+            href="/menu-accueil"
+            className="bg-gray-800 hover:bg-gray-900 text-white rounded p-1"
+          >
+            <CakeLogo className="mr-0" showText={false} />
+          </Link>
           {childrenArray.map((child, i) => (
             <span key={i} className="flex items-center">{child}</span>
           ))}

--- a/components/character/ImportExportMenu.tsx
+++ b/components/character/ImportExportMenu.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { FC, useRef, useState } from 'react'
+import { Folder } from 'lucide-react'
 import { defaultPerso } from '../sheet/CharacterSheet' // <-- AJOUT
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -106,10 +107,11 @@ const ImportExportMenu: FC<Props> = ({ perso, onUpdate }) => {
   return (
     <div className="relative inline-block ml-2">
       <button
-        className="bg-gray-800 hover:bg-gray-700 text-white text-xs px-2 py-1 rounded shadow transition-all"
+        className="bg-gray-800 hover:bg-gray-700 text-white p-2 rounded shadow transition-all"
         onClick={() => setOpen(v => !v)}
+        aria-label="Import / Export"
       >
-        Import/Export
+        <Folder size={16} />
       </button>
       {open && (
         <div className="absolute right-0 mt-2 z-50 w-56 bg-[#18181b] border border-gray-700 rounded-xl shadow-2xl py-2 flex flex-col gap-1 animate-fadeIn">

--- a/components/character/ImportExportMenu.tsx
+++ b/components/character/ImportExportMenu.tsx
@@ -114,7 +114,7 @@ const ImportExportMenu: FC<Props> = ({ perso, onUpdate }) => {
         <Folder size={16} />
       </button>
       {open && (
-        <div className="absolute right-0 mt-2 z-50 w-56 bg-[#18181b] border border-gray-700 rounded-xl shadow-2xl py-2 flex flex-col gap-1 animate-fadeIn">
+        <div className="absolute top-full left-full mt-2 ml-2 z-50 w-56 bg-black/35 backdrop-blur-md border border-white/10 rounded-xl shadow-2xl py-2 flex flex-col gap-1 animate-fadeIn">
           <button onClick={handleExport} className="w-full px-3 py-1 rounded hover:bg-gray-800 text-left text-sm">📤 Exporter la fiche</button>
           <label className="w-full px-3 py-1 rounded hover:bg-gray-800 text-left text-sm cursor-pointer">
             📥 Importer une fiche

--- a/components/character/LevelUpPanel.tsx
+++ b/components/character/LevelUpPanel.tsx
@@ -81,13 +81,15 @@ const LevelUpPanel: FC<Props> = ({
           <option key={d.value} value={d.value}>{d.label}</option>
         ))}
       </select>
-      <button
-        onClick={onLevelUp}
-        disabled={processing}
-        className="w-full bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
-      >
-        {processing ? "Lancement..." : "Lancer Level Up"}
-      </button>
+      <div className="flex justify-center mt-2">
+        <button
+          onClick={onLevelUp}
+          disabled={processing}
+          className="bg-blue-600/80 hover:bg-blue-600 text-white font-semibold px-4 py-1.5 rounded-md shadow disabled:opacity-50"
+        >
+          {processing ? 'Lancement...' : 'Lancer Level Up'}
+        </button>
+      </div>
 
       <AnimatePresence>
         {lastGain !== null && (

--- a/components/chat/OnlineProfiles.tsx
+++ b/components/chat/OnlineProfiles.tsx
@@ -31,15 +31,25 @@ export default function OnlineProfiles() {
   if (entries.length === 0) return null
 
   // flex-row-reverse : le dernier connecté apparaît à gauche de la liste
+  const getTextColor = (hex: string) => {
+    const c = hex.replace('#', '')
+    const r = parseInt(c.substring(0, 2), 16)
+    const g = parseInt(c.substring(2, 4), 16)
+    const b = parseInt(c.substring(4, 6), 16)
+    const yiq = (r * 299 + g * 587 + b * 114) / 1000
+    return yiq >= 128 ? '#000' : '#fff'
+  }
+
   return (
     <div className="flex flex-row-reverse gap-2">
       {entries.map(([id, p]) => (
         <div
           key={id}
-          className="w-4 h-4 rounded-full border border-white"
-          style={{ backgroundColor: p.color }}
-          title={p.pseudo}
-        />
+          className="w-6 h-6 rounded-full border border-white flex items-center justify-center text-[10px] font-bold"
+          style={{ backgroundColor: p.color, color: getTextColor(p.color) }}
+        >
+          {p.pseudo.charAt(0).toUpperCase()}
+        </div>
       ))}
     </div>
   )

--- a/components/menu/CharacterList.tsx
+++ b/components/menu/CharacterList.tsx
@@ -68,7 +68,7 @@ const CharacterList: FC<Props> = ({
                   flex flex-col gap-2 min-h-[120px] 
                   transition
                   ${isSelected
-                    ? 'ring-2 ring-emerald-400/70'
+                    ? 'ring-2 ring-emerald-400/90 shadow-[0_0_12px_2px_rgba(16,185,129,0.6)]'
                     : 'hover:ring-2 hover:ring-emerald-300/40'}
                 `}
                 style={{

--- a/components/menu/MenuAccueil.tsx
+++ b/components/menu/MenuAccueil.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { useState, useEffect, useRef } from 'react'
+import { Crown } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import Login from '../login/Login'
 import { defaultPerso } from '../sheet/CharacterSheet'
@@ -11,6 +12,7 @@ import CharacterModal from './CharacterModal'
 import ProfileColorPicker from './ProfileColorPicker'
 
 const PROFILE_KEY = 'jdr_profile'
+const SELECTED_KEY = 'selectedCharacterId'
 
 type Character = {
   id: string | number
@@ -46,7 +48,14 @@ export default function MenuAccueil() {
         }
       }
       const savedChars = JSON.parse(localStorage.getItem('jdr_characters') || '[]')
-      if (Array.isArray(savedChars)) setCharacters(savedChars)
+      if (Array.isArray(savedChars)) {
+        setCharacters(savedChars)
+        const selId = localStorage.getItem(SELECTED_KEY)
+        if (selId) {
+          const idx = savedChars.findIndex((c: any) => c.id?.toString() === selId)
+          if (idx !== -1) setSelectedIdx(idx)
+        }
+      }
     } catch {}
   }, [])
 
@@ -104,7 +113,6 @@ export default function MenuAccueil() {
   }
 
   /* --------- Characters CRUD --------- */
-  const handleSelectChar   = (idx:number) => setSelectedIdx(idx)
   const handleNewCharacter = () => {
     if (!user) return
     setDraftChar({ ...defaultPerso, id: crypto.randomUUID(), owner: user.pseudo })
@@ -114,19 +122,34 @@ export default function MenuAccueil() {
 
   const handleSaveDraft = () => {
     if (!user) return
-    const toSave = { ...draftChar, nom: draftChar.nom || 'Sans nom', owner: user.pseudo }
-    const updated = draftChar.id && characters.find(c => c.id === draftChar.id)
-      ? characters.map(c => (c.id === draftChar.id ? toSave : c))
+    const id = draftChar.id || crypto.randomUUID()
+    const toSave = { ...draftChar, id, nom: draftChar.nom || 'Sans nom', owner: user.pseudo }
+    const updated = characters.find(c => c.id === id)
+      ? characters.map(c => (c.id === id ? toSave : c))
       : [...characters, toSave]
     saveCharacters(updated)
+    localStorage.setItem(SELECTED_KEY, String(id))
     setModalOpen(false)
-    setSelectedIdx(updated.findIndex(c => c.id === toSave.id))
+    setSelectedIdx(updated.findIndex(c => c.id === id))
   }
 
   const handleDeleteChar = (idx:number) => {
     if (!window.confirm('Supprimer cette fiche ?')) return
-    saveCharacters(characters.filter((_, i) => i !== idx))
-    setSelectedIdx(null)
+    const toDelete = characters[idx]
+    const remaining = characters.filter((_, i) => i !== idx)
+    saveCharacters(remaining)
+    if (toDelete?.id && localStorage.getItem(SELECTED_KEY) === String(toDelete.id)) {
+      localStorage.removeItem(SELECTED_KEY)
+      setSelectedIdx(null)
+    } else {
+      const id = localStorage.getItem(SELECTED_KEY)
+      if (id) {
+        const newIdx = remaining.findIndex(c => String(c.id) === id)
+        setSelectedIdx(newIdx !== -1 ? newIdx : null)
+      } else {
+        setSelectedIdx(null)
+      }
+    }
   }
 
   /* --------- Import / Export --------- */
@@ -138,8 +161,12 @@ export default function MenuAccueil() {
     reader.onload = evt => {
       try {
         const imported = JSON.parse(evt.target?.result as string)
+        const id = imported.id || crypto.randomUUID()
         if (!imported.owner && user) imported.owner = user.pseudo
-        saveCharacters([...characters, imported])
+        const withId = { ...imported, id }
+        saveCharacters([...characters, withId])
+        localStorage.setItem(SELECTED_KEY, String(id))
+        setSelectedIdx(characters.length)
         alert('Fiche importée !')
       } catch { alert('Erreur : fichier invalide.') }
     }
@@ -192,6 +219,14 @@ export default function MenuAccueil() {
   const filteredCharacters = user
     ? user.isMJ ? characters : characters.filter(c => c.owner === user.pseudo)
     : []
+
+  const handleSelectChar = (idx: number) => {
+    setSelectedIdx(idx)
+    const ch = filteredCharacters[idx]
+    if (ch?.id !== undefined) {
+      localStorage.setItem(SELECTED_KEY, String(ch.id))
+    }
+  }
 
   /* Pendant logout : écran neutre (rien de l'ancien UI ne reste) */
   if (loggingOut) {
@@ -268,7 +303,7 @@ export default function MenuAccueil() {
                 }}
               >
                 <span className="flex items-center gap-1">
-                  <span className="text-xs tracking-wide">MJ</span>
+                  <Crown size={18} className="text-pink-400" />
                   <span
                     className={`
                       block w-2.5 h-2.5 rounded-full transition

--- a/components/menu/ProfileColorPicker.tsx
+++ b/components/menu/ProfileColorPicker.tsx
@@ -73,7 +73,7 @@ const ProfileColorPicker: FC<Props> = ({ color, onChange, size = 28 }) => {
           `}
           style={{ textShadow: '0 1px 2px rgba(0,0,0,0.6)' }}
         >
-          {open ? '–' : '▸'}
+          {open ? '-' : '+'}
         </span>
       </button>
 

--- a/components/misc/GMCharacterSelector.tsx
+++ b/components/misc/GMCharacterSelector.tsx
@@ -78,8 +78,8 @@ export default function GMCharacterSelector({ onSelect, buttonLabel = 'Personnag
         aria-haspopup="listbox"
         aria-expanded={open}
       >
-        <User2 size={16} className="mr-1" />
-        {buttonLabel}
+        <User2 size={16} className={buttonLabel ? 'mr-1' : ''} />
+        {buttonLabel && buttonLabel}
       </button>
       {open && (
         <div className="absolute left-0 mt-1 w-48 bg-white dark:bg-gray-900 text-gray-900 dark:text-white rounded shadow-lg border border-purple-500 z-50 py-1">


### PR DESCRIPTION
## Summary
- add selected character persistence and unique ID logic
- use crown icon for MJ toggle
- use cake icon as main menu button
- replace Import/Export text with folder icon
- support icon-only GM selector

## Testing
- `npm install`
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d48d70354832ea0c8da7b0fa8ad65