### PR TITLE
Fix error handling in RoomsPanel

### DIFF
--- a/components/menu/CharacterList.tsx
+++ b/components/menu/CharacterList.tsx
@@ -274,32 +274,29 @@ const CharacterList: FC<Props> = ({
           <Download size={17} /> Export
         </button>
         {/* Bouton Cloud ouvrant un petit menu */}
-        <button
-          onClick={() => setShowCloud(v => !v)}
-          className={
-            btnBase +
-            " hover:bg-pink-600/80 text-pink-100 font-bold flex items-center gap-2"
-          }
-
-          title="Cloud options"
-
-
-        >
-          <CloudUpload size={18} />
-          Cloud
-        </button>
+        <div className="relative">
+          <button
+            onClick={() => setShowCloud(v => !v)}
+            className={
+              btnBase +
+              " hover:bg-pink-600/80 text-pink-100 font-bold flex items-center gap-2"
+            }
+            title="Cloud options"
+          >
+            <CloudUpload size={18} />
+            Cloud
+          </button>
+          {showCloud && (
+            <div className="absolute left-0 top-full mt-2 z-50 w-44 bg-black/75 border border-white/20 rounded-xl shadow-2xl backdrop-blur-md p-2 flex flex-col gap-1">
+              <button onClick={handleCloudImport} className="px-3 py-1 text-left hover:bg-gray-800 rounded">Import from Cloud</button>
+              <button onClick={handleCloudExport} className="px-3 py-1 text-left hover:bg-gray-800 rounded">Export to Cloud</button>
+            </div>
+          )}
+        </div>
         {/* Indicateur de synchronisation */}
         {syncing && <span className="ml-1 animate-pulse">⏳</span>}
         {syncSuccess && <span className="ml-1 text-emerald-400">✔</span>}
         {syncError && <span className="ml-1 text-red-400">✖</span>}
-        {showCloud && (
-          <div className="absolute z-50 mt-2 right-0 bg-black/80 border border-white/20 rounded-xl p-2 flex flex-col gap-1">
-
-            <button onClick={handleCloudImport} className="px-3 py-1 text-left hover:bg-gray-800 rounded">Import from Cloud</button>
-            <button onClick={handleCloudExport} className="px-3 py-1 text-left hover:bg-gray-800 rounded">Export to Cloud</button>
-
-          </div>
-        )}
         <input
           type="file"
           accept="text/plain,application/json"

--- a/components/menu/MenuAccueil.tsx
+++ b/components/menu/MenuAccueil.tsx
@@ -32,11 +32,9 @@ export default function MenuAccueil() {
   const [draftChar, setDraftChar]     = useState<Character>(defaultPerso as unknown as Character)
   const [hydrated, setHydrated]       = useState(false)
   const [loggingOut, setLoggingOut]   = useState(false)
-  const [diceHover, setDiceHover]     = useState(false)
-  const [roomsOpen, setRoomsOpen]     = useState(false)
-  const [panelPos, setPanelPos]       = useState<{left:number;top:number}|null>(null)
+  const [diceHover, setDiceHover] = useState(false)
+  const [roomsOpen, setRoomsOpen] = useState(false)
 
-  const diceRef = useRef<HTMLButtonElement | null>(null)
 
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
@@ -125,15 +123,6 @@ export default function MenuAccueil() {
   }
 
   const handlePlay = () => {
-    if (!roomsOpen) {
-      const rect = diceRef.current?.getBoundingClientRect()
-      if (rect) {
-        setPanelPos({
-          left: rect.right + 8 + window.scrollX,
-          top: rect.top + window.scrollY,
-        })
-      }
-    }
     setRoomsOpen(v => !v)
   }
 
@@ -288,7 +277,6 @@ export default function MenuAccueil() {
                 {/* Button to open the room list */}
 
                 <button
-                  ref={diceRef}
                   type="button"
                   aria-label="Open game rooms"
                   onClick={handlePlay}
@@ -376,11 +364,8 @@ export default function MenuAccueil() {
                 </button>
               </div>
             </section>
-            {roomsOpen && panelPos && (
-              <RoomsPanel
-                onClose={() => setRoomsOpen(false)}
-                style={{ left: panelPos.left, top: panelPos.top }}
-              />
+            {roomsOpen && (
+              <RoomsPanel onClose={() => setRoomsOpen(false)} />
             )}
 
             {/* Liste des personnages */}


### PR DESCRIPTION
## Summary
- handle network errors when listing rooms
- add check for successful room creation
- centralize the room creation panel with cleaner styling
- restyle the cloud import/export menu and anchor below the button

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68815d8e168c832e90136925c2143349