### PR TITLE
Update env variable names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
-CLOUDINARY_CLOUD_NAME=
+CLOUDINARY_URL=
 
-# Public API key for your Cloudinary account
-CLOUDINARY_KEY=983753278431369
-CLOUDINARY_API_SECRET=
 # Public Liveblocks API key used on the client
+NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY=
 
-LIVEBLOCKS_KEY=pk_dev_TyJoLcNht-pFDqJxctnpShxkV4xgYWWVcZMibBSthGiESihddBYvPocQp3qZBFQq
+# Secret Liveblocks key for server-side operations
+LIVEBLOCKS_SECRET_KEY=
+
+# Vercel Blob authentication tokens
+BLOB_READ_WRITE_TOKEN=
+VERCEL_OIDC_TOKEN=

--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -4,11 +4,11 @@ import { LiveblocksProvider, RoomProvider, ClientSideSuspense } from "@liveblock
 
 export function Room({ id, children }: { id: string; children: ReactNode }) {
 
-  // LIVEBLOCKS_KEY contains the public API key for the Liveblocks project.
-  // It is exposed via next.config.ts. If it's missing we cannot connect.
-  const key = process.env.LIVEBLOCKS_KEY;
+  // NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY contains the public API key for the Liveblocks project.
+  // It is exposed via the environment. If it's missing we cannot connect.
+  const key = process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY;
   if (!key) {
-    throw new Error('LIVEBLOCKS_KEY is not defined');
+    throw new Error('NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY is not defined');
   }
 
   return (

--- a/app/api/cloudinary/route.ts
+++ b/app/api/cloudinary/route.ts
@@ -6,19 +6,15 @@ import { v2 as cloudinary } from 'cloudinary'
 // builds won't fail if they are missing. A runtime error is still returned
 // when configuration is incomplete.
 function configureCloudinary(): boolean {
-  const { CLOUDINARY_CLOUD_NAME, CLOUDINARY_KEY, CLOUDINARY_API_SECRET } =
-    process.env
+  const { CLOUDINARY_URL } = process.env
 
-  if (!CLOUDINARY_CLOUD_NAME || !CLOUDINARY_KEY || !CLOUDINARY_API_SECRET) {
-    console.error('Missing Cloudinary configuration environment variables')
+  if (!CLOUDINARY_URL) {
+    console.error('Missing CLOUDINARY_URL environment variable')
     return false
   }
 
-  cloudinary.config({
-    cloud_name: CLOUDINARY_CLOUD_NAME,
-    api_key: CLOUDINARY_KEY,
-    api_secret: CLOUDINARY_API_SECRET,
-  })
+  // The Cloudinary SDK parses CLOUDINARY_URL automatically when config is called.
+  cloudinary.config({ secure: true })
   return true
 }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,7 +12,7 @@ const nextConfig: NextConfig = {
   env: {
 
     // Expose the public Liveblocks key to client components.
-    LIVEBLOCKS_KEY: process.env.LIVEBLOCKS_KEY,
+    NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY: process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY,
 
   },
 };


### PR DESCRIPTION
## Summary
- rename env variables to new names in Next config and Room
- update Cloudinary route to expect `CLOUDINARY_URL`
- refresh `.env.example` with new variable names

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68822e1a1238832ea470319ff56ec1e2