### PR TITLE
Make rooms permanent and fix image upload

### DIFF
--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -17,7 +17,7 @@ export async function POST(req: Request) {
     const { name, password } = await req.json()
     const id = `${name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${Date.now()}`
   const rooms = await readRooms()
-  rooms.push({ id, name, password, emptySince: null })
+  rooms.push({ id, name, password })
   const blob = await put(FILE, JSON.stringify(rooms), {
     access: 'public',
     addRandomSuffix: false,

--- a/app/rooms/page.tsx
+++ b/app/rooms/page.tsx
@@ -8,6 +8,7 @@ export default function RoomsPage() {
   const [password, setPassword] = useState('')
   const [showCreate, setShowCreate] = useState(false)
   const [withPassword, setWithPassword] = useState(false)
+  const [errorMsg, setErrorMsg] = useState('')
   const router = useRouter()
 
   useEffect(() => {
@@ -18,12 +19,18 @@ export default function RoomsPage() {
 
   const createRoom = async () => {
     if (!name) return
+    try {
+      const prof = JSON.parse(localStorage.getItem('jdr_profile') || '{}')
+      if (!prof.isMJ) { setErrorMsg('Active MJ mode before creating a room'); return }
+      if (localStorage.getItem('jdr_my_room')) { setErrorMsg('You already created a room'); return }
+    } catch {}
     const res = await fetch('/api/rooms', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, password })
     })
     const data = await res.json()
+    localStorage.setItem('jdr_my_room', data.id)
     router.push(`/room/${data.id}`)
   }
 
@@ -106,6 +113,9 @@ export default function RoomsPage() {
               Confirm
 
             </button>
+            {errorMsg && (
+              <p className="text-red-400 text-sm text-center mt-2">{errorMsg}</p>
+            )}
           </div>
         )}
       </details>

--- a/components/canvas/InteractiveCanvas.tsx
+++ b/components/canvas/InteractiveCanvas.tsx
@@ -119,8 +119,9 @@ export default function InteractiveCanvas() {
     const form = new FormData()
     form.append('file', file)
     const res = await fetch('/api/cloudinary', { method: 'POST', body: form })
-    const data = await res.json()
-    return data.url as string
+    if (!res.ok) return null
+    const data = await res.json().catch(() => null)
+    return (data && data.url) ? (data.url as string) : null
   }
 
   const handleDrop = (e: React.DragEvent) => {
@@ -131,6 +132,7 @@ export default function InteractiveCanvas() {
     files.forEach(async (file) => {
       if (file.type.startsWith('image/') && rect) {
         const url = await uploadImage(file)
+        if (!url) return
         const newImg = {
           id: Date.now() + Math.random(),
           src: url,

--- a/components/rooms/RoomSaver.tsx
+++ b/components/rooms/RoomSaver.tsx
@@ -14,19 +14,10 @@ async function compress(txt: string) {
   return new Uint8Array(buf)
 }
 
-export default function RoomSaver({ roomName, roomId }: { roomName: string; roomId: string }) {
+export default function RoomSaver({ roomName }: { roomName: string; roomId: string }) {
   const room = useRoom()
 
   useEffect(() => {
-    const updateStatus = async (empty: boolean) => {
-      await fetch('/api/rooms', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: roomId, empty }),
-        keepalive: true,
-      })
-    }
-
     const handleUnload = async () => {
       if (room.getOthers().length === 0) {
         const history = localStorage.getItem('jdr_dice_history')
@@ -37,16 +28,14 @@ export default function RoomSaver({ roomName, roomId }: { roomName: string; room
             data
           )
         }
-        await updateStatus(true)
       }
     }
-    updateStatus(false)
     window.addEventListener('beforeunload', handleUnload)
     return () => {
       handleUnload()
       window.removeEventListener('beforeunload', handleUnload)
     }
-  }, [room, roomName, roomId])
+  }, [room, roomName])
 
   return null
 }

--- a/components/rooms/RoomsPanel.tsx
+++ b/components/rooms/RoomsPanel.tsx
@@ -10,6 +10,7 @@ export default function RoomsPanel({ onClose }: Props) {
   const [name, setName] = useState('')
   const [withPassword, setWithPassword] = useState(false)
   const [password, setPassword] = useState('')
+  const [errorMsg, setErrorMsg] = useState('')
   const panelRef = useRef<HTMLDivElement>(null)
   const router = useRouter()
 
@@ -26,6 +27,11 @@ export default function RoomsPanel({ onClose }: Props) {
 
   const createRoom = async () => {
     if (!name) return
+    try {
+      const prof = JSON.parse(localStorage.getItem('jdr_profile') || '{}')
+      if (!prof.isMJ) { setErrorMsg('Active MJ mode before creating a room'); return }
+      if (localStorage.getItem('jdr_my_room')) { setErrorMsg('You already created a room'); return }
+    } catch {}
     const res = await fetch('/api/rooms', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -33,6 +39,7 @@ export default function RoomsPanel({ onClose }: Props) {
     })
     if (!res.ok) return
     const data = await res.json()
+    localStorage.setItem('jdr_my_room', data.id)
     onClose?.()
     router.push(`/room/${data.id}`)
   }
@@ -109,6 +116,9 @@ export default function RoomsPanel({ onClose }: Props) {
           Create
 
         </button>
+        {errorMsg && (
+          <p className="text-red-400 text-sm mt-2 text-center">{errorMsg}</p>
+        )}
       </div>
     </div>
   </div>

--- a/lib/rooms.ts
+++ b/lib/rooms.ts
@@ -1,4 +1,4 @@
-import { put, list } from '@vercel/blob'
+import { list } from '@vercel/blob'
 
 const FILE = 'rooms.json'
 
@@ -24,17 +24,8 @@ export async function readRooms(): Promise<Room[]> {
   const res = await fetch(roomsUrl)
   const data = await res.json().catch(() => [])
   if (!Array.isArray(data)) return []
-  const valid = data.filter((r: Room) => !(r.emptySince && now - r.emptySince > 120000))
-  if (valid.length !== data.length) {
-    const uploaded = await put(FILE, JSON.stringify(valid), {
-      access: 'public',
-      addRandomSuffix: false,
-      allowOverwrite: true,
-    })
-    roomsUrl = uploaded.downloadUrl || uploaded.url
-  }
-  cached = { rooms: valid, ts: Date.now() }
-  return valid
+  cached = { rooms: data, ts: Date.now() }
+  return data
 }
 
 export function updateRoomsCache(rooms: Room[], url?: string) {


### PR DESCRIPTION
## Summary
- keep all rooms by removing old-room cleanup logic
- ensure room creation requires being MJ and only one room per user
- remove status updates from RoomSaver
- improve image upload error handling

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6882322e38d0832e9023f83bcfd95ca6