### PR TITLE
Implement password prompt and chat pseudo

### DIFF
--- a/app/rooms/page.tsx
+++ b/app/rooms/page.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 
 export default function RoomsPage() {
-  const [rooms, setRooms] = useState<{id:string,name:string}[]>([])
+  const [rooms, setRooms] = useState<{id:string,name:string,password?:string}[]>([])
   const [name, setName] = useState('')
   const [password, setPassword] = useState('')
   const [showCreate, setShowCreate] = useState(false)
@@ -34,8 +34,12 @@ export default function RoomsPage() {
     router.push(`/room/${data.id}`)
   }
 
-  const joinRoom = (id:string) => {
-    router.push(`/room/${id}`)
+  const joinRoom = (room:{id:string,name:string,password?:string}) => {
+    if (room.password) {
+      const pwd = prompt('Enter room password')
+      if (pwd !== room.password) { alert('Incorrect password'); return }
+    }
+    router.push(`/room/${room.id}`)
   }
 
   return (
@@ -50,7 +54,7 @@ export default function RoomsPage() {
           <li key={r.id} className="mb-2">
             {r.name}
 
-            <button onClick={() => joinRoom(r.id)} className="ml-2 underline">Join</button>
+            <button onClick={() => joinRoom(r)} className="ml-2 underline">Join</button>
 
 
 
@@ -106,6 +110,7 @@ export default function RoomsPage() {
               />
             )}
             <button
+              type="button"
               onClick={createRoom}
               className="px-4 py-2 bg-blue-600 rounded text-white w-full"
             >

--- a/components/chat/ChatBox.tsx
+++ b/components/chat/ChatBox.tsx
@@ -33,9 +33,13 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history }) => {
   const sendMessage = () => {
     if (inputValue.trim() === '') return
 
-    const msg = { author: 'You', text: inputValue.trim() }
+    let pseudo = 'You'
+    try {
+      const prof = JSON.parse(localStorage.getItem('jdr_profile') || '{}')
+      if (prof.pseudo) pseudo = prof.pseudo
+    } catch {}
 
-
+    const msg = { author: pseudo, text: inputValue.trim() }
 
     setMessages(prev => [...prev, msg])
     broadcast({ type: 'chat', author: msg.author, text: msg.text })

--- a/components/rooms/RoomsPanel.tsx
+++ b/components/rooms/RoomsPanel.tsx
@@ -44,9 +44,13 @@ export default function RoomsPanel({ onClose }: Props) {
     router.push(`/room/${data.id}`)
   }
 
-  const joinRoom = (id: string) => {
+  const joinRoom = (room: {id:string;name:string;password?:string}) => {
+    if (room.password) {
+      const pwd = prompt('Enter room password')
+      if (pwd !== room.password) { alert('Incorrect password'); return }
+    }
     onClose?.()
-    router.push(`/room/${id}`)
+    router.push(`/room/${room.id}`)
   }
 
   return (
@@ -72,7 +76,7 @@ export default function RoomsPanel({ onClose }: Props) {
               </span>
               <button
                 className="px-2 py-1 bg-pink-700/50 hover:bg-pink-700/70 rounded text-sm"
-                onClick={() => joinRoom(r.id)}
+                onClick={() => joinRoom(r)}
               >
 
                 Join
@@ -109,6 +113,7 @@ export default function RoomsPanel({ onClose }: Props) {
           />
         )}
         <button
+          type="button"
           className="w-full px-3 py-2 rounded-md bg-emerald-600 hover:bg-emerald-500 text-white font-semibold"
           onClick={createRoom}
         >


### PR DESCRIPTION
## Summary
- add password prompt before joining a room
- use user's pseudo from localStorage in chat messages
- fix potential page reload on room creation by using `type="button"`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68823f9ca2c8832e82b8aa11b80e28f8