### PR TITLE
Improve character cloud UI and chat pseudo

### DIFF
--- a/components/app/HomePageInner.tsx
+++ b/components/app/HomePageInner.tsx
@@ -41,6 +41,8 @@ export default function HomePageInner() {
     const { event } = payload
     if (event.type === 'dice-roll') {
       setHistory((h) => [...h, { player: event.player, dice: event.dice, result: event.result }])
+    } else if (event.type === 'gm-select') {
+      setPerso(event.character)
     }
   })
 
@@ -148,7 +150,7 @@ export default function HomePageInner() {
           </DiceRoller>
         </main>
 
-        <ChatBox chatBoxRef={chatBoxRef} history={history} />
+        <ChatBox chatBoxRef={chatBoxRef} history={history} pseudo={profile?.pseudo || user || ''} />
         <SideNotes />
       </div>
       <Head>

--- a/components/canvas/InteractiveCanvas.tsx
+++ b/components/canvas/InteractiveCanvas.tsx
@@ -32,7 +32,7 @@ export default function InteractiveCanvas() {
 
   const broadcast = useBroadcastEvent()
   const lastSend = useRef(0)
-  const THROTTLE = 30
+  const THROTTLE = 0
 
   const canvasRef = useRef<HTMLDivElement>(null)
   const drawingCanvasRef = useRef<HTMLCanvasElement>(null)
@@ -192,7 +192,7 @@ export default function InteractiveCanvas() {
       ctxRef.current.stroke()
       const { x: px, y: py } = mousePos
       const now = Date.now()
-      if (now - lastSend.current > THROTTLE) {
+      if (THROTTLE === 0 || now - lastSend.current > THROTTLE) {
         lastSend.current = now
         broadcast({ type: 'draw-line', x1: px, y1: py, x2: x, y2: y, color, width: brushSize, mode: drawMode })
       }

--- a/components/chat/ChatBox.tsx
+++ b/components/chat/ChatBox.tsx
@@ -9,9 +9,10 @@ type Roll = { player: string, dice: number, result: number }
 type Props = {
   chatBoxRef: RefObject<HTMLDivElement | null>
   history: Roll[]
+  pseudo: string
 }
 
-const ChatBox: FC<Props> = ({ chatBoxRef, history }) => {
+const ChatBox: FC<Props> = ({ chatBoxRef, history, pseudo }) => {
   const [messages, setMessages] = useState([
     { author: 'GM', text: 'Welcome!' }
   ])
@@ -33,9 +34,7 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history }) => {
   const sendMessage = () => {
     if (inputValue.trim() === '') return
 
-    const msg = { author: 'You', text: inputValue.trim() }
-
-
+    const msg = { author: pseudo || 'Anonymous', text: inputValue.trim() }
 
     setMessages(prev => [...prev, msg])
     broadcast({ type: 'chat', author: msg.author, text: msg.text })

--- a/components/misc/GMCharacterSelector.tsx
+++ b/components/misc/GMCharacterSelector.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { useEffect, useState, useRef } from 'react'
+import { useBroadcastEvent } from '@liveblocks/react'
 import { User2 } from 'lucide-react'
 
 const STORAGE_KEY = 'jdr_characters'
@@ -21,6 +22,7 @@ export default function GMCharacterSelector({
   const [open, setOpen] = useState(false)
   const [selectedId, setSelectedId] = useState<number | null>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const broadcast = useBroadcastEvent()
 
   useEffect(() => {
     const update = () => setChars(loadCharacters())
@@ -64,7 +66,10 @@ export default function GMCharacterSelector({
     setSelectedId(id)
     const list = loadCharacters()
     const found = list.find((c: any) => c.id === id)
-    if (found) onSelect(found)
+    if (found) {
+      onSelect(found)
+      broadcast({ type: 'gm-select', character: found })
+    }
     setOpen(false)
   }
 


### PR DESCRIPTION
## Summary
- add modal dialogs for cloud import/export/delete of character sheets
- show player pseudo instead of "You" in chat
- throttle-free canvas drawing
- support room passwords and creation progress
- broadcast GM character selection

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68837407d63c832ea72a82a52cc67a2e