### PR TITLE
Add save API and improve cloud import

### DIFF
--- a/app/api/save/route.ts
+++ b/app/api/save/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { put } from '@vercel/blob'
+import { createClient } from '@liveblocks/node'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { roomId, chatHistory = '' } = await req.json()
+    if (!roomId) {
+      return NextResponse.json({ error: 'roomId missing' }, { status: 400 })
+    }
+    const secret = process.env.LIVEBLOCKS_SECRET_KEY
+    if (!secret) {
+      return NextResponse.json({ error: 'Liveblocks key missing' }, { status: 500 })
+    }
+    const client = createClient({ secret })
+    const storage = await client.getStorageDocument(roomId, 'json').catch(() => null)
+    const data = storage as Record<string, unknown> | null
+    const characters = data && data.characters ? data.characters : {}
+    const ts = Date.now()
+    const charPath = `FichesSauvegardes/${roomId}-${ts}.json`
+    const chatPath = `HistoriqueChat/${roomId}-${ts}.txt`
+    const [charBlob, chatBlob] = await Promise.all([
+      put(charPath, JSON.stringify(characters), { access: 'public' }),
+      put(chatPath, chatHistory, { access: 'public' })
+    ])
+    return NextResponse.json({
+      characters: charBlob.url || charBlob.downloadUrl,
+      chat: chatBlob.url || chatBlob.downloadUrl,
+    })
+  } catch {
+    return NextResponse.json({ error: 'save failed' }, { status: 500 })
+  }
+}

--- a/components/chat/ChatBox.tsx
+++ b/components/chat/ChatBox.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { FC, RefObject, useRef, useState, useEffect } from 'react'
-import { useBroadcastEvent, useEventListener } from '@liveblocks/react'
+import { useBroadcastEvent, useEventListener, useRoom } from '@liveblocks/react'
 import SummaryPanel from './SummaryPanel'
 import DiceStats from './DiceStats'
 
@@ -21,6 +21,7 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history }) => {
   const [showStats, setShowStats] = useState(false)
   const prevHist = useRef(0)
   const broadcast = useBroadcastEvent()
+  const room = useRoom()
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   useEventListener((payload: any) => {
@@ -40,6 +41,17 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history }) => {
     setMessages(prev => [...prev, msg])
     broadcast({ type: 'chat', author: msg.author, text: msg.text })
     setInputValue('')
+  }
+
+  const saveSession = async () => {
+    try {
+      const historyText = messages.map(m => `${m.author}: ${m.text}`).join('\n')
+      await fetch('/api/save', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ roomId: room.id, chatHistory: historyText })
+      })
+    } catch {}
   }
 
   useEffect(() => {
@@ -130,6 +142,14 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history }) => {
           title="Stats DD"
         >
           {showStats ? 'Chat' : '📊'}
+        </button>
+        <button
+          className="px-5 py-2 rounded-xl font-semibold shadow border-none bg-black/30 text-white/90 hover:bg-emerald-600 hover:text-white transition duration-100 flex items-center justify-center min-h-[44px]"
+          style={{ minHeight: 44 }}
+          onClick={saveSession}
+          title="Save session"
+        >
+          💾
         </button>
       </div>
 

--- a/liveblocks.config.ts
+++ b/liveblocks.config.ts
@@ -1,17 +1,15 @@
 // Define Liveblocks types for your application
 // https://liveblocks.io/docs/api-reference/liveblocks-react#Typing-your-data
+import type { LiveMap } from '@liveblocks/client'
 declare global {
   interface Liveblocks {
     // Each user's Presence, for useMyPresence, useOthers, etc.
-    Presence: {
-      // Example, real-time cursor coordinates
-      // cursor: { x: number; y: number };
-    };
+    Presence: Record<string, never>;
 
     // The Storage tree for the room, for useMutation, useStorage, etc.
     Storage: {
-      // Example, a conflict-free list
-      // animals: LiveList<string>;
+      characters: LiveMap<Record<string, unknown>>;
+      images: LiveMap<Record<string, unknown>>;
     };
 
     // Custom user info set when authenticating with a secret key
@@ -25,10 +23,15 @@ declare global {
     };
 
     // Custom events, for useBroadcastEvent, useEventListener
-    RoomEvent: {};
-      // Example has two events, using a union
-      // | { type: "PLAY" } 
-      // | { type: "REACTION"; emoji: "🔥" };
+    RoomEvent:
+      | { type: 'add-image'; image: Record<string, unknown> }
+      | { type: 'update-image'; image: Record<string, unknown> }
+      | { type: 'delete-image'; id: number }
+      | { type: 'clear-canvas' }
+      | { type: 'draw-line'; x1:number; y1:number; x2:number; y2:number; color:string; width:number; mode:'draw'|'erase' }
+      | { type: 'chat'; author: string; text: string }
+      | { type: 'dice-roll'; player: string; dice: number; result: number }
+      | { type: 'gm-select'; character: Record<string, unknown> };
 
     // Custom metadata set on threads, for useThreads, useCreateThread, etc.
     ThreadMetadata: {


### PR DESCRIPTION
## Summary
- add `/api/save` endpoint to archive character storage and chat history to Blob
- enhance character list cloud import with a file chooser dialog
- expose new events and storage types in `liveblocks.config.ts`
- allow saving session from chat box

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68838ac1603c832e99e59692f81cd5f6