### PR TITLE
Fix summary panel infinite update

### DIFF
--- a/components/chat/SummaryPanel.tsx
+++ b/components/chat/SummaryPanel.tsx
@@ -151,15 +151,25 @@ const SummaryPanel: FC<Props> = ({ onClose }) => {
   // Sync from Liveblocks storage
   useEffect(() => {
     if (summaryObj && Array.isArray(summaryObj.acts)) {
-      setActs(summaryObj.acts.length ? summaryObj.acts : [{ id: 1, title: '', content: '' }])
+      const nextActs = summaryObj.acts.length
+        ? summaryObj.acts
+        : [{ id: 1, title: '', content: '' }]
+      setActs(prev =>
+        JSON.stringify(prev) === JSON.stringify(nextActs) ? prev : nextActs
+      )
     }
   }, [summaryObj])
 
   // Persist locally and in Liveblocks
   useEffect(() => {
     localStorage.setItem(LOCAL_KEY, JSON.stringify(acts))
-    updateSummary(acts)
-  }, [acts, updateSummary])
+    if (
+      summaryObj &&
+      JSON.stringify(summaryObj.acts) !== JSON.stringify(acts)
+    ) {
+      updateSummary(acts)
+    }
+  }, [acts, summaryObj, updateSummary])
 
   useEffect(() => {
     const selectedAct = acts.find(a => a.id === selectedId)


### PR DESCRIPTION
## Summary
- prevent repeated `setActs` when summary data hasn't changed
- avoid Liveblocks update if data is already in sync

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688527e1fbdc832e9a576bad0a339c16