### PR TITLE
Implement unified chat log and avatar stack

### DIFF
--- a/components/app/HomePageInner.tsx
+++ b/components/app/HomePageInner.tsx
@@ -10,7 +10,7 @@ import ChatBox from '@/components/chat/ChatBox'
 import PopupResult from '@/components/dice/PopupResult'
 import Head from 'next/head'
 import InteractiveCanvas from '@/components/canvas/InteractiveCanvas'
-import OnlineProfiles from '@/components/chat/OnlineProfiles'
+import LiveAvatarStack from '@/components/chat/LiveAvatarStack'
 import SideNotes from '@/components/misc/SideNotes'
 import Login from '@/components/login/Login'
 import GMCharacterSelector from '@/components/misc/GMCharacterSelector'
@@ -44,7 +44,6 @@ export default function HomePageInner() {
     const { event } = payload
     if (event.type === 'dice-roll') {
       setHistory((h) => [...h, { player: event.player, dice: event.dice, result: event.result, ts: Date.now() }])
-      addEvent({ id: crypto.randomUUID(), kind: 'dice', player: event.player, dice: event.dice, result: event.result, ts: Date.now() })
     } else if (event.type === 'gm-select') {
       const char = event.character || defaultPerso
       if (!char.id) char.id = crypto.randomUUID()
@@ -171,7 +170,7 @@ export default function HomePageInner() {
             <PopupResult show={showPopup} result={diceResult} diceType={diceType} onFinish={handlePopupFinish} />
           </div>
           <DiceRoller diceType={diceType} onChange={setDiceType} onRoll={rollDice} disabled={diceDisabled}>
-            <OnlineProfiles />
+            <LiveAvatarStack />
           </DiceRoller>
         </main>
 

--- a/components/canvas/InteractiveCanvas.tsx
+++ b/components/canvas/InteractiveCanvas.tsx
@@ -25,7 +25,9 @@ export default function InteractiveCanvas() {
   const [isDrawing, setIsDrawing] = useState(false)
   const [drawMode, setDrawMode] = useState<'images' | 'draw' | 'erase'>('images')
   const [color, setColor] = useState('#000000')
-  const [brushSize, setBrushSize] = useState(10)
+  const [penSize, setPenSize] = useState(10)
+  const [eraserSize, setEraserSize] = useState(20)
+  const brushSize = drawMode === 'erase' ? eraserSize : penSize
   const [mousePos, setMousePos] = useState({ x: 0, y: 0 })
   const [toolsVisible, setToolsVisible] = useState(false)
   const [audioVisible, setAudioVisible] = useState(false)
@@ -135,20 +137,17 @@ export default function InteractiveCanvas() {
     const canvas = drawingCanvasRef.current
     if (!canvas) return
 
-    if (drawMode === 'draw' || drawMode === 'erase') {
-      canvas.style.zIndex = '2'
-      canvas.style.pointerEvents = 'auto'
-    } else {
-      canvas.style.zIndex = '0'
-      canvas.style.pointerEvents = 'none'
-    }
+    canvas.style.zIndex = '2'
+    canvas.style.pointerEvents = drawMode === 'images' ? 'none' : 'auto'
   }, [drawMode])
 
   useEffect(() => {
-    const min = drawMode === 'erase' ? ERASE_MIN : DRAW_MIN
-    const max = drawMode === 'erase' ? ERASE_MAX : DRAW_MAX
-    setBrushSize((bs) => Math.min(Math.max(bs, min), max))
-  }, [ERASE_MAX, ERASE_MIN, drawMode])
+    if (drawMode === 'erase') {
+      setEraserSize((s) => Math.min(Math.max(s, ERASE_MIN), ERASE_MAX))
+    } else {
+      setPenSize((s) => Math.min(Math.max(s, DRAW_MIN), DRAW_MAX))
+    }
+  }, [drawMode, DRAW_MIN, DRAW_MAX, ERASE_MIN, ERASE_MAX])
 
   useEffect(() => {
     if (playerRef.current) {
@@ -407,7 +406,11 @@ export default function InteractiveCanvas() {
             min={drawMode === 'erase' ? ERASE_MIN : DRAW_MIN}
             max={drawMode === 'erase' ? ERASE_MAX : DRAW_MAX}
             value={brushSize}
-            onChange={(e) => setBrushSize(parseInt(e.target.value, 10))}
+            onChange={(e) => {
+              const v = parseInt(e.target.value, 10)
+              if (drawMode === 'erase') setEraserSize(v)
+              else setPenSize(v)
+            }}
             className="w-24 mx-2"
           />
           {COLORS.map((c) => (

--- a/components/chat/LiveAvatarStack.tsx
+++ b/components/chat/LiveAvatarStack.tsx
@@ -1,0 +1,40 @@
+'use client'
+import { useOthers } from '@liveblocks/react'
+
+export default function LiveAvatarStack() {
+  const others = useOthers()
+  if (others.length === 0) return null
+
+  const getTextColor = (hex: string) => {
+    const c = hex.replace('#', '')
+    const r = parseInt(c.substring(0,2),16)
+    const g = parseInt(c.substring(2,4),16)
+    const b = parseInt(c.substring(4,6),16)
+    const yiq = (r*299 + g*587 + b*114)/1000
+    return yiq >= 128 ? '#000' : '#fff'
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 z-40 flex flex-row-reverse gap-2">
+      {others.map(({ connectionId, presence }) => {
+        const name = presence?.name as string | undefined
+        const color = (presence?.color as string) || '#888'
+        if (!name) return null
+        const text = getTextColor(color)
+        return (
+          <div key={connectionId} className="relative group">
+            <div
+              className="w-6 h-6 rounded-full border border-white flex items-center justify-center text-[10px] font-bold"
+              style={{ backgroundColor: color, color: text }}
+            >
+              {name.charAt(0).toUpperCase()}
+            </div>
+            <div className="absolute bottom-full right-0 mb-1 px-2 py-1 rounded bg-black text-white text-xs whitespace-nowrap opacity-0 group-hover:opacity-100 pointer-events-none">
+              {name}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- merge chat and dice events in `ChatBox`
- keep drawing canvas above images and maintain pen/eraser sizes separately
- show online users with new `LiveAvatarStack`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68868f65a404832e80a65783aec784e0