### PR TITLE
Implement dynamic dice roll reveal

### DIFF
--- a/components/app/HomePageInner.tsx
+++ b/components/app/HomePageInner.tsx
@@ -142,15 +142,17 @@ export default function HomePageInner() {
     setPendingRoll({ result, dice: diceType, nom: perso.nom || '?' })
   }
 
-  const handlePopupFinish = () => {
-    setShowPopup(false)
-    setDiceDisabled(false)
+  const handlePopupReveal = () => {
     if (!pendingRoll) return
-
     setHistory((h) => [...h, { player: pendingRoll.nom, dice: pendingRoll.dice, result: pendingRoll.result, ts: Date.now() }])
     broadcast({ type: 'dice-roll', player: pendingRoll.nom, dice: pendingRoll.dice, result: pendingRoll.result } as Liveblocks['RoomEvent'])
     addEvent({ id: crypto.randomUUID(), kind: 'dice', player: pendingRoll.nom, dice: pendingRoll.dice, result: pendingRoll.result, ts: Date.now() })
     setPendingRoll(null)
+  }
+
+  const handlePopupFinish = () => {
+    setShowPopup(false)
+    setDiceDisabled(false)
   }
 
   return (
@@ -167,7 +169,13 @@ export default function HomePageInner() {
         <main className="flex-1 flex flex-col min-h-0">
           <div className="flex-1 m-4 flex flex-col justify-center items-center relative min-h-0">
             <InteractiveCanvas />
-            <PopupResult show={showPopup} result={diceResult} diceType={diceType} onFinish={handlePopupFinish} />
+            <PopupResult
+              show={showPopup}
+              result={diceResult}
+              diceType={diceType}
+              onReveal={handlePopupReveal}
+              onFinish={handlePopupFinish}
+            />
           </div>
           <DiceRoller diceType={diceType} onChange={setDiceType} onRoll={rollDice} disabled={diceDisabled}>
             <LiveAvatarStack />

--- a/components/dice/PopupResult.tsx
+++ b/components/dice/PopupResult.tsx
@@ -7,50 +7,84 @@ interface Props {
   show: boolean
   result: number | null
   diceType: number
+  onReveal?: () => void
   onFinish?: () => void
 }
 
 const DiceFace: FC<{ value: string | number }> = ({ value }) => (
   <motion.div
+    key={String(value)}
     initial={{ scale: 0, rotate: 0, opacity: 0 }}
     animate={{ scale: 1.2, rotate: 360, opacity: 1 }}
-    transition={{ duration: 0.6 }}
+    transition={{ duration: 0.3 }}
     className="flex items-center justify-center w-32 h-32 text-black text-6xl font-extrabold rounded-2xl bg-white border-4 border-gray-400 shadow-xl select-none"
   >
     {value}
   </motion.div>
 )
 
-const NeoDice3D: FC<Props> = ({ show, result, diceType, onFinish }) => {
+const NeoDice3D: FC<Props> = ({ show, result, diceType, onReveal, onFinish }) => {
   const [visible, setVisible] = useState(false)
+  const [display, setDisplay] = useState<number | null>(null)
+  const [rolling, setRolling] = useState(false)
 
   useEffect(() => {
     if (show && result !== null) {
       setVisible(true)
-      const timeout = setTimeout(() => {
+      setRolling(true)
+      setDisplay(Math.floor(Math.random() * diceType) + 1)
+      const interval = setInterval(() => {
+        setDisplay(Math.floor(Math.random() * diceType) + 1)
+      }, 100)
+      const revealTimeout = setTimeout(() => {
+        clearInterval(interval)
+        setDisplay(result)
+        setRolling(false)
+        onReveal?.()
+      }, 1000)
+      const hideTimeout = setTimeout(() => {
         setVisible(false)
         onFinish?.()
-      }, 3000) // dé visible 3s
-
-      return () => clearTimeout(timeout)
+      }, 2000)
+      return () => {
+        clearInterval(interval)
+        clearTimeout(revealTimeout)
+        clearTimeout(hideTimeout)
+      }
     }
-  }, [show, result, onFinish])
+  }, [show, result, diceType, onReveal, onFinish])
 
-  if (!visible || result === null) return null
+  if (!visible || display === null) return null
 
-  const isCrit = result === diceType
-  const isFail = result === 1
+  const isCrit = !rolling && display === diceType
+  const isFail = !rolling && display === 1
 
   const bgGlow = isCrit
-    ? 'shadow-[0_0_60px_rgba(253,224,71,0.8)]'
+    ? 'shadow-[0_0_60px_rgba(253,224,71,0.9)]'
     : isFail
-    ? 'shadow-[0_0_60px_rgba(239,68,68,0.8)]'
-    : 'shadow-[0_0_40px_rgba(96,165,250,0.6)]'
+    ? 'shadow-[0_0_60px_rgba(239,68,68,0.9)]'
+    : 'shadow-[0_0_40px_rgba(96,165,250,0.7)]'
 
   return (
     <div className="fixed inset-0 flex items-center justify-center pointer-events-none z-[9999]">
-      <div className={`${bgGlow} rounded-2xl`}>
-        <DiceFace value={result} />
+      <div className={`${bgGlow} rounded-2xl relative`}>
+        <DiceFace value={display} />
+        {isCrit && (
+          <motion.div
+            className="absolute inset-0 rounded-2xl border-4 border-yellow-300"
+            initial={{ opacity: 0, scale: 1 }}
+            animate={{ opacity: [0.8, 0], scale: [1.2, 1.6] }}
+            transition={{ duration: 0.6 }}
+          />
+        )}
+        {isFail && (
+          <motion.div
+            className="absolute inset-0 rounded-2xl border-4 border-red-400"
+            initial={{ x: 0 }}
+            animate={{ x: [0, -8, 8, -8, 8, 0] }}
+            transition={{ duration: 0.6 }}
+          />
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- add dice result reveal callback in `PopupResult`
- implement animated roll with critical success/fail effects
- update `HomePageInner` to log dice result when animation reveals

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68873a691170832eb0faf917b63eed96