### PR TITLE
Improve character cloud actions and room loading

### DIFF
--- a/components/menu/CharacterList.tsx
+++ b/components/menu/CharacterList.tsx
@@ -1,5 +1,6 @@
 import { FC, RefObject } from 'react'
-import { Edit2, Trash2, Plus, Upload, Download } from 'lucide-react'
+import { Edit2, Trash2, Plus, Upload, Download, Cloud } from 'lucide-react'
+import { AnimatePresence, motion } from 'framer-motion'
 
 export type Character = {
   id: string | number
@@ -77,6 +78,7 @@ const CharacterList: FC<Props> = ({
         }
         return (
         <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
+          <AnimatePresence initial={false}>
           {all.map((ch, idx) => {
             const isSelected = selectedIdx !== null && filtered[selectedIdx]?.id === ch.id
             const localIdx = filtered.findIndex(c => String(c.id) === String(ch.id))
@@ -87,7 +89,7 @@ const CharacterList: FC<Props> = ({
             const needsDownload = (!local && cloud) || (local && cloud && (cloudChar.updatedAt || 0) > (localChar?.updatedAt || 0))
             const needsUpload = local && (!cloud || (localChar?.updatedAt || 0) > (cloudChar?.updatedAt || 0))
             return (
-              <li
+              <motion.li
                 key={`${ch.id}-${idx}`}
                 onClick={() => onSelect(local ? filtered.findIndex(c => String(c.id)===String(ch.id)) : -1)}
                 className={`
@@ -108,6 +110,10 @@ const CharacterList: FC<Props> = ({
                     : '0 0 0 1px rgba(255,255,255,0.03), 0 2px 6px -4px rgba(0,0,0,0.50)'
                 }}
                     title={ch.nom || 'No name'}
+                initial={{ opacity: 0, scale: 0.95 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.95 }}
+                layout
               >
                 <div className="flex items-start justify-between gap-2">
                   <span
@@ -116,54 +122,26 @@ const CharacterList: FC<Props> = ({
                   >
                     {ch.nom || 'No name'}
                   </span>
-                  <div className="flex items-center gap-1 shrink-0">
-                    {needsUpload && (
+                  {local && (
+                    <div className="flex items-center gap-1 shrink-0">
                       <button
-                        onClick={e => { e.stopPropagation(); onUpload(local ? filtered[localIdx] : ch) }}
-                        className={btnBase + ' hover:bg-cyan-600/80 text-cyan-100 w-8 h-8'}
-                        title={cloud ? 'Update cloud' : 'Upload'}
+                        onClick={e => { e.stopPropagation(); onEdit(ch.id) }}
+                        className={btnBase + ' hover:bg-yellow-500/90 text-yellow-100 w-8 h-8'}
+                        title="Edit"
                       >
-                        <Upload size={16} />
+                        <Edit2 size={16} />
                       </button>
-                    )}
-                    {needsDownload ? (
                       <button
-                        onClick={e => { e.stopPropagation(); onDownload(cloudChar || ch) }}
-                        className={btnBase + ' hover:bg-emerald-600/80 text-emerald-100 w-8 h-8'}
-                        title="Download"
-                      >
-                        <Download size={16} />
-                      </button>
-                    ) : null}
-                    {cloud && (
-                      <button
-                        onClick={e => { e.stopPropagation(); onDeleteCloud(ch.id) }}
-                        className={btnBase + ' hover:bg-red-700/80 text-red-100 w-8 h-8'}
-                        title="Delete cloud"
+                        onClick={e => { e.stopPropagation(); onDelete(ch.id) }}
+                        className={btnBase + ' hover:bg-red-600/90 text-red-100 w-8 h-8'}
+                        title="Delete"
                       >
                         <Trash2 size={16} />
                       </button>
-                    )}
-                    {local && (
-                    <>
-                      <button
-                        onClick={e => { e.stopPropagation(); onEdit(ch.id) }}
-                      className={btnBase + " hover:bg-yellow-500/90 text-yellow-100 w-8 h-8"}
-                      title="Edit"
-                    >
-                      <Edit2 size={16} />
-                    </button>
-                    <button
-                      onClick={e => { e.stopPropagation(); onDelete(ch.id) }}
-                      className={btnBase + " hover:bg-red-600/90 text-red-100 w-8 h-8"}
-                      title="Delete"
-                    >
-                      <Trash2 size={16} />
-                    </button>
-                    </>) }
-                  </div>
+                    </div>
+                  )}
                 </div>
-                <div className="flex flex-col gap-1 text-xs text-white/85 mt-1">
+                <div className="flex flex-col gap-1 text-xs text-white/85 mt-1 flex-1">
                   {ch.niveau !== undefined && (
                     <div>
                       <span className="font-medium text-emerald-200">Niveau</span> {ch.niveau}
@@ -185,9 +163,40 @@ const CharacterList: FC<Props> = ({
                     </div>
                   )}
                 </div>
-              </li>
+                <div className="flex items-center gap-1 justify-end mt-auto">
+                  {cloud && <Cloud size={14} className="text-blue-200/80" />}
+                  {needsUpload && (
+                    <button
+                      onClick={e => { e.stopPropagation(); onUpload(local ? filtered[localIdx] : ch) }}
+                      className={btnBase + ' hover:bg-cyan-600/80 text-cyan-100 w-8 h-8'}
+                      title={cloud ? 'Update cloud' : 'Upload'}
+                    >
+                      <Upload size={16} />
+                    </button>
+                  )}
+                  {needsDownload && (
+                    <button
+                      onClick={e => { e.stopPropagation(); onDownload(cloudChar || ch) }}
+                      className={btnBase + ' hover:bg-emerald-600/80 text-emerald-100 w-8 h-8'}
+                      title="Download"
+                    >
+                      <Download size={16} />
+                    </button>
+                  )}
+                  {cloud && (
+                    <button
+                      onClick={e => { e.stopPropagation(); onDeleteCloud(ch.id) }}
+                      className={btnBase + ' hover:bg-red-700/80 text-red-100 w-8 h-8'}
+                      title="Delete cloud"
+                    >
+                      <Trash2 size={16} />
+                    </button>
+                  )}
+                </div>
+              </motion.li>
             )
           })}
+          </AnimatePresence>
         </ul>
         )
       })()}

--- a/components/menu/MenuAccueil.tsx
+++ b/components/menu/MenuAccueil.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { Crown, LogOut, Dice6 } from 'lucide-react'
+import SmallSpinner from '../ui/SmallSpinner'
 import RoomList, { RoomInfo } from '../rooms/RoomList'
 import RoomCreateModal from '../rooms/RoomCreateModal'
 import { useRouter } from 'next/navigation'
@@ -41,6 +42,7 @@ export default function MenuAccueil() {
   const [createRoomOpen, setCreateRoomOpen] = useState(false)
   const [selectedRoom, setSelectedRoom] = useState<RoomInfo | null>(null)
   const [remoteChars, setRemoteChars] = useState<Record<string, Character>>({})
+  const [roomLoading, setRoomLoading] = useState(false)
 
 
   const fileInputRef = useRef<HTMLInputElement | null>(null)
@@ -70,10 +72,12 @@ export default function MenuAccueil() {
           const r = JSON.parse(roomRaw)
           if (r?.id) {
             setSelectedRoom(r)
+            setRoomLoading(true)
             fetch(`/api/roomstorage?roomId=${encodeURIComponent(r.id)}`)
               .then(res => res.json())
               .then(data => setRemoteChars(data.characters || {}))
               .catch(() => setRemoteChars({}))
+              .finally(() => setRoomLoading(false))
           }
         } catch {}
       }
@@ -148,6 +152,7 @@ export default function MenuAccueil() {
 
   const handleRoomSelect = (room: RoomInfo) => {
     setSelectedRoom(room)
+    setRoomLoading(true)
     localStorage.setItem(ROOM_KEY, JSON.stringify(room))
     fetch(`/api/roomstorage?roomId=${encodeURIComponent(room.id)}`)
       .then(res => res.json())
@@ -172,6 +177,7 @@ export default function MenuAccueil() {
         }
       })
       .catch(() => {})
+      .finally(() => setRoomLoading(false))
     setRoomsOpen(false)
   }
 
@@ -400,7 +406,8 @@ export default function MenuAccueil() {
                 </button>
               </div>
               {selectedRoom && (
-                <span className="ml-2 text-sm text-white/80">
+                <span className="ml-2 text-sm text-white/80 flex items-center gap-2">
+                  {roomLoading && <SmallSpinner />}
                   {selectedRoom.name}
                 </span>
               )}

--- a/components/ui/SmallSpinner.tsx
+++ b/components/ui/SmallSpinner.tsx
@@ -1,0 +1,10 @@
+'use client'
+import { FC } from 'react'
+
+const SmallSpinner: FC<{ className?: string }> = ({ className = '' }) => (
+  <span
+    className={`inline-block w-4 h-4 border-2 border-transparent border-t-white rounded-full animate-spin ${className}`}
+  />
+)
+
+export default SmallSpinner


### PR DESCRIPTION
## Summary
- move cloud actions to bottom right of character items
- animate character list items and add cloud icon
- add a small spinner component
- show spinner while loading a room's characters

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68873ddad2b0832ea7c8ac0ed0481637