### PR TITLE
Responsive room list with Liveblocks

### DIFF
--- a/components/app/HomePageInner.tsx
+++ b/components/app/HomePageInner.tsx
@@ -155,7 +155,7 @@ export default function HomePageInner() {
 
   return (
     <div className="relative w-screen h-screen font-sans overflow-hidden bg-transparent">
-      <div className="relative z-10 flex w-full h-full">
+      <div className="relative z-10 flex flex-col lg:flex-row w-full h-full">
         <CharacterSheet perso={perso} onUpdate={handleUpdatePerso} chatBoxRef={chatBoxRef} allCharacters={characters} logoOnly>
           {profile?.isMJ && (
             <span className="ml-2">

--- a/components/app/hooks/useEventLog.ts
+++ b/components/app/hooks/useEventLog.ts
@@ -10,6 +10,7 @@ export type SessionEvent = {
   dice?: number
   result?: number
   ts: number
+  isMJ?: boolean
 }
 
 const prefix = 'jdr_events_'

--- a/components/chat/ChatBox.tsx
+++ b/components/chat/ChatBox.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { FC, RefObject, useRef, useState, useEffect } from 'react'
 import { useBroadcastEvent, useRoom } from '@liveblocks/react'
+import useProfile from '../app/hooks/useProfile'
 import SummaryPanel from './SummaryPanel'
 import DiceStats from './DiceStats'
 import useEventLog from '../app/hooks/useEventLog'
@@ -22,15 +23,16 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author }) => {
   const [showSummary, setShowSummary] = useState(false)
   const [showStats, setShowStats] = useState(false)
   const broadcast = useBroadcastEvent()
+  const profile = useProfile()
 
 
   const sendMessage = () => {
     if (inputValue.trim() === '') return
 
-    const msg = { author, text: inputValue.trim() }
+    const msg = { author, text: inputValue.trim(), isMJ: profile?.isMJ }
 
-    broadcast({ type: 'chat', author: msg.author, text: msg.text } as Liveblocks['RoomEvent'])
-    addEvent({ id: crypto.randomUUID(), kind: 'chat', author: msg.author, text: msg.text, ts: Date.now() })
+    broadcast({ type: 'chat', author: msg.author, text: msg.text, isMJ: msg.isMJ } as Liveblocks['RoomEvent'])
+    addEvent({ id: crypto.randomUUID(), kind: 'chat', author: msg.author, text: msg.text, ts: Date.now(), isMJ: msg.isMJ })
     setInputValue('')
   }
 
@@ -44,7 +46,7 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author }) => {
     return (
       <aside
         className="
-          w-1/5
+          w-full lg:w-1/5
           p-4
           flex flex-col relative
           rounded-xl
@@ -66,7 +68,7 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author }) => {
   return (
     <aside
       className="
-        w-1/5
+        w-full lg:w-1/5
         p-4
         flex flex-col relative h-full min-h-0
         rounded-xl
@@ -153,7 +155,7 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author }) => {
               <p key={ev.id}>
                 <span className="mr-1">{ev.kind === 'chat' ? '💬' : '🎲'}</span>
                 {ev.kind === 'chat' && (
-                  <><strong>{ev.author} :</strong> {ev.text}</>
+                  <><strong>{ev.author}{ev.isMJ && ' 👑'} :</strong> {ev.text}</>
                 )}
                 {ev.kind === 'dice' && (
                   <span>{ev.player} : D{ev.dice} → {ev.result}</span>

--- a/components/menu/MenuAccueil.tsx
+++ b/components/menu/MenuAccueil.tsx
@@ -6,6 +6,7 @@ import { Crown, LogOut, Dice6 } from 'lucide-react'
 import SmallSpinner from '../ui/SmallSpinner'
 import RoomList, { RoomInfo } from '../rooms/RoomList'
 import RoomCreateModal from '../rooms/RoomCreateModal'
+import RoomsIndexProvider from '../rooms/RoomsIndexProvider'
 import { useRouter } from 'next/navigation'
 import Login from '../login/Login'
 import { defaultPerso } from '../sheet/CharacterSheet'
@@ -37,8 +38,6 @@ export default function MenuAccueil() {
   const [draftChar, setDraftChar]     = useState<Character>(defaultPerso as unknown as Character)
   const [hydrated, setHydrated]       = useState(false)
   const [loggingOut, setLoggingOut]   = useState(false)
-  const [diceHover, setDiceHover] = useState(false)
-  const [roomsOpen, setRoomsOpen] = useState(false)
   const [createRoomOpen, setCreateRoomOpen] = useState(false)
   const [selectedRoom, setSelectedRoom] = useState<RoomInfo | null>(null)
   const [remoteChars, setRemoteChars] = useState<Record<string, Character>>({})
@@ -147,7 +146,11 @@ export default function MenuAccueil() {
   }
 
   const handlePlay = () => {
-    setRoomsOpen(v => !v)
+    if (!selectedRoom) return
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem('visitedMenu', 'true')
+    }
+    router.push(`/room/${selectedRoom.id}`)
   }
 
   const handleRoomSelect = (room: RoomInfo) => {
@@ -345,45 +348,24 @@ export default function MenuAccueil() {
             >
               <div className="shrink-0 flex items-center justify-start min-w-[150px] gap-2">
 
-                {/* Button to open the room list */}
-
                 <button
                   type="button"
-                  aria-label="Open game rooms"
+                  aria-label="Enter room"
                   onClick={handlePlay}
-                  onMouseEnter={() => setDiceHover(true)}
-                  onMouseLeave={() => setDiceHover(false)}
-                  className="relative inline-flex items-center justify-center rounded-md border-2 border-pink-300/40 shadow-md shadow-pink-200/20 transition focus:outline-none focus:ring-2 focus:ring-pink-200/40 focus:ring-offset-2 focus:ring-offset-black"
+                  className={`relative inline-flex items-center justify-center rounded-md border-2 border-pink-300/40 shadow-md shadow-pink-200/20 transition focus:outline-none focus:ring-2 focus:ring-pink-200/40 focus:ring-offset-2 focus:ring-offset-black ${selectedRoom ? 'animate-pulse' : ''}`}
                   style={{
                     width: DICE_SIZE,
                     height: DICE_SIZE,
-                    background: 'rgba(38,16,56,0.14)',
-                    borderColor: diceHover ? '#ff90cc' : '#f7bbf7',
-                    boxShadow: diceHover
+                    background: selectedRoom ? 'rgba(38,16,56,0.2)' : 'rgba(38,16,56,0.14)',
+                    borderColor: selectedRoom ? '#ff90cc' : '#f7bbf7',
+                    boxShadow: selectedRoom
                       ? '0 0 12px 2px #ffb0e366, 0 2px 20px 8px #fff2'
                       : '0 0 4px 1px #ffe5fa44, 0 2px 8px 2px #fff2',
-                    transition: 'transform 0.18s cubic-bezier(.77,.2,.56,1), box-shadow 0.18s cubic-bezier(.77,.2,.56,1)',
-                    transform: diceHover ? 'scale(1.15) rotate(-7deg)' : 'scale(1) rotate(0deg)'
+                    transition: 'transform 0.18s cubic-bezier(.77,.2,.56,1), box-shadow 0.18s cubic-bezier(.77,.2,.56,1)'
                   }}
+                  disabled={!selectedRoom}
                 >
                   <Dice6 className="w-5 h-5 text-white drop-shadow-[0_2px_5px_rgba(255,70,190,0.45)]" />
-                </button>
-                <button
-                  type="button"
-                  disabled={!selectedRoom}
-                  className={`px-3 py-1.5 rounded-md text-sm shadow transition-colors
-                    ${selectedRoom
-                      ? 'bg-emerald-600 text-white hover:bg-emerald-500'
-                      : 'bg-gray-600 text-gray-300 cursor-not-allowed'}`}
-                  onClick={() => {
-                    if (!selectedRoom) return
-                    if (typeof window !== 'undefined') {
-                      sessionStorage.setItem('visitedMenu', 'true')
-                    }
-                    router.push(`/room/${selectedRoom.id}`)
-                  }}
-                >
-                  Jouer
                 </button>
               </div>
               {selectedRoom && (
@@ -458,21 +440,15 @@ export default function MenuAccueil() {
                 </button>
               </div>
             </section>
-            {roomsOpen && (
-              <div
-                className="fixed inset-0 z-50 flex items-center justify-center p-4"
-                onClick={() => setRoomsOpen(false)}
-                style={{ background: 'rgba(0,0,0,0.45)', backdropFilter: 'blur(2px)' }}
-              >
-                <div onClick={e => e.stopPropagation()}>
-                  <RoomList
-                    selectedId={selectedRoom?.id || null}
-                    onSelect={handleRoomSelect}
-                    onCreateClick={() => setCreateRoomOpen(true)}
-                  />
-                </div>
+            <RoomsIndexProvider>
+              <div className="mb-4">
+                <RoomList
+                  selectedId={selectedRoom?.id || null}
+                  onSelect={handleRoomSelect}
+                  onCreateClick={() => setCreateRoomOpen(true)}
+                />
               </div>
-            )}
+            </RoomsIndexProvider>
             <RoomCreateModal
               open={createRoomOpen}
               onClose={() => setCreateRoomOpen(false)}

--- a/components/rooms/RoomsIndexProvider.tsx
+++ b/components/rooms/RoomsIndexProvider.tsx
@@ -1,0 +1,18 @@
+'use client'
+import { ReactNode } from 'react'
+import { LiveblocksProvider, RoomProvider, ClientSideSuspense } from '@liveblocks/react/suspense'
+import { LiveList } from '@liveblocks/client'
+
+export default function RoomsIndexProvider({ children }: { children: ReactNode }) {
+  const key = process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY
+  if (!key) throw new Error('NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY is not defined')
+  return (
+    <LiveblocksProvider publicApiKey={key}>
+      <RoomProvider id="rooms-index" initialPresence={{}} initialStorage={{ rooms: new LiveList([]) }}>
+        <ClientSideSuspense fallback={<div>Loading…</div>}>
+          {children}
+        </ClientSideSuspense>
+      </RoomProvider>
+    </LiveblocksProvider>
+  )
+}

--- a/components/sheet/CharacterSheet.tsx
+++ b/components/sheet/CharacterSheet.tsx
@@ -172,15 +172,16 @@ const CharacterSheet: FC<Props> = ({
   return (
     <aside
       className="
+        w-full md:w-[420px]
         bg-black/10 border border-white/10 backdrop-blur-[2px]
         shadow shadow-black/5 rounded-2xl p-5
         pt-0 pb-3 px-3 overflow-y-auto text-[15px] text-white
         relative select-none
       "
       style={{
-        width: creation ? 'auto' : '420px',
-        minWidth: creation ? '600px' : '420px',
-        maxWidth: creation ? '100%' : '420px',
+        width: creation ? 'auto' : undefined,
+        minWidth: creation ? '600px' : undefined,
+        maxWidth: creation ? '100%' : undefined,
         boxSizing: 'border-box',
         overflowX: 'hidden'
       }}

--- a/liveblocks.config.ts
+++ b/liveblocks.config.ts
@@ -21,6 +21,14 @@ type SessionEvent = {
   dice?: number
   result?: number
   ts: number
+  isMJ?: boolean
+}
+
+type Room = {
+  id: string
+  name: string
+  password?: string
+  owner?: string | null
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -45,6 +53,7 @@ declare global {
       music: LiveObject<{ id: string; playing: boolean }>;
       summary: LiveObject<{ acts: Array<{ id: number; title: string; content: string }> }>;
       events: LiveList<SessionEvent>;
+      rooms: LiveList<Room>;
     };
 
     // Custom user info set when authenticating with a secret key
@@ -64,7 +73,7 @@ declare global {
       | { type: 'delete-image'; id: number }
       | { type: 'clear-canvas' }
       | { type: 'draw-line'; x1:number; y1:number; x2:number; y2:number; color:string; width:number; mode:'draw'|'erase' }
-      | { type: 'chat'; author: string; text: string }
+      | { type: 'chat'; author: string; text: string; isMJ?: boolean }
       | { type: 'dice-roll'; player: string; dice: number; result: number }
       | { type: 'gm-select'; character: CharacterData };
 


### PR DESCRIPTION
## Summary
- store MJ flag and room list types in `liveblocks.config`
- provide `RoomsIndexProvider` for rooms index connection
- fetch rooms from Liveblocks in `RoomList` and redesign as cards
- integrate real-time room list in menu and use dice to join
- add crown indicator for GM messages in chat
- make layout responsive on small screens

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6887aeb8b548832e9a9f13aff998332b