### PR TITLE
Fix cursor layering above canvas drawings

### DIFF
--- a/components/canvas/Cursor.tsx
+++ b/components/canvas/Cursor.tsx
@@ -4,7 +4,7 @@ import { motion } from 'framer-motion'
 export default function Cursor({ x, y, color, name }: { x:number; y:number; color:string; name?:string }) {
   return (
     <motion.div
-      className="absolute top-0 left-0 pointer-events-none"
+      className="absolute top-0 left-0 pointer-events-none z-20"
       initial={{ x, y }}
       animate={{ x, y }}
       transition={{ type: 'spring', stiffness: 300, damping: 30 }}


### PR DESCRIPTION
## Summary
- ensure live cursors render above canvas drawings and images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888dcd82564832ebba92aeeeb06e3a0