### PR TITLE
Display online players in room list

### DIFF
--- a/app/rooms/page.tsx
+++ b/app/rooms/page.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 
 export default function RoomsPage() {
-  const [rooms, setRooms] = useState<Array<{ id: string; name: string; createdAt?: string; updatedAt?: string }>>([])
+  const [rooms, setRooms] = useState<Array<{ id: string; name: string; createdAt?: string; updatedAt?: string; usersConnected?: number }>>([])
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [name, setName] = useState('')
   const [password, setPassword] = useState('')
@@ -78,6 +78,9 @@ export default function RoomsPage() {
           >
             <span className="truncate block">{r.name || 'Unnamed'}</span>
             <span className="text-xs text-white/60">{r.createdAt ? new Date(r.createdAt).toLocaleDateString() : ''}</span>
+            {typeof r.usersConnected === 'number' && r.usersConnected > 0 && (
+              <span className="text-xs text-white/50">{r.usersConnected} online</span>
+            )}
             <button
               className="text-sm underline"
               onClick={e => { e.stopPropagation(); joinRoom(r.id) }}


### PR DESCRIPTION
## Summary
- show number of connected users on `/rooms` page

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888dcfc569c832e87bb56158761e350