### PR TITLE
Display avatars for active users

### DIFF
--- a/app/rooms/page.tsx
+++ b/app/rooms/page.tsx
@@ -1,9 +1,10 @@
 'use client'
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import RoomAvatarStack from '@/components/rooms/RoomAvatarStack'
 
 export default function RoomsPage() {
-  const [rooms, setRooms] = useState<Array<{ id: string; name: string; createdAt?: string; updatedAt?: string }>>([])
+  const [rooms, setRooms] = useState<Array<{ id: string; name: string; createdAt?: string; updatedAt?: string; usersConnected?: number }>>([])
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [name, setName] = useState('')
   const [password, setPassword] = useState('')
@@ -78,6 +79,7 @@ export default function RoomsPage() {
           >
             <span className="truncate block">{r.name || 'Unnamed'}</span>
             <span className="text-xs text-white/60">{r.createdAt ? new Date(r.createdAt).toLocaleDateString() : ''}</span>
+            <RoomAvatarStack id={r.id} />
             <button
               className="text-sm underline"
               onClick={e => { e.stopPropagation(); joinRoom(r.id) }}

--- a/components/chat/LiveAvatarStack.tsx
+++ b/components/chat/LiveAvatarStack.tsx
@@ -1,7 +1,12 @@
 'use client'
 import { useOthers } from '@liveblocks/react'
 
-export default function LiveAvatarStack() {
+interface Props {
+  className?: string
+  size?: number
+}
+
+export default function LiveAvatarStack({ className = 'fixed bottom-4 right-4 z-40 flex flex-row-reverse gap-2', size = 24 }: Props) {
   const others = useOthers()
   if (others.length === 0) return null
 
@@ -15,7 +20,7 @@ export default function LiveAvatarStack() {
   }
 
   return (
-    <div className="fixed bottom-4 right-4 z-40 flex flex-row-reverse gap-2">
+    <div className={className}>
       {others.map(({ connectionId, presence }) => {
         const name = presence?.name as string | undefined
         const color = (presence?.color as string) || '#888'
@@ -24,8 +29,8 @@ export default function LiveAvatarStack() {
         return (
           <div key={connectionId} className="relative group">
             <div
-              className="w-6 h-6 rounded-full border border-white flex items-center justify-center text-[10px] font-bold"
-              style={{ backgroundColor: color, color: text }}
+              className="rounded-full border border-white flex items-center justify-center font-bold select-none"
+              style={{ backgroundColor: color, color: text, width: size, height: size, fontSize: size * 0.42 }}
             >
               {name.charAt(0).toUpperCase()}
             </div>

--- a/components/rooms/RoomAvatarStack.tsx
+++ b/components/rooms/RoomAvatarStack.tsx
@@ -1,0 +1,29 @@
+'use client'
+import { LiveblocksProvider, RoomProvider, ClientSideSuspense } from '@liveblocks/react/suspense'
+import { LiveMap, LiveObject, LiveList } from '@liveblocks/client'
+import LiveAvatarStack from '../chat/LiveAvatarStack'
+
+export default function RoomAvatarStack({ id }: { id: string }) {
+  const key = process.env.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY
+  if (!key) return null
+  return (
+    <LiveblocksProvider publicApiKey={key}>
+      <RoomProvider
+        id={id}
+        initialPresence={{}}
+        initialStorage={{
+          characters: new LiveMap(),
+          images: new LiveMap(),
+          music: new LiveObject({ id: '', playing: false }),
+          summary: new LiveObject({ acts: [] }),
+          events: new LiveList([]),
+          rooms: new LiveList([])
+        }}
+      >
+        <ClientSideSuspense fallback={null}>
+          <LiveAvatarStack className="flex flex-row-reverse gap-1" size={20} />
+        </ClientSideSuspense>
+      </RoomProvider>
+    </LiveblocksProvider>
+  )
+}

--- a/components/rooms/RoomList.tsx
+++ b/components/rooms/RoomList.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
 import { Lock } from 'lucide-react'
+import RoomAvatarStack from './RoomAvatarStack'
 
 export type RoomInfo = {
   id: string
@@ -131,9 +132,7 @@ export default function RoomList({ onSelect, selectedId, onCreateClick }: Props)
             <span className="text-xs text-white/60 truncate">
               {r.updatedAt ? new Date(r.updatedAt).toLocaleDateString() : new Date(r.createdAt ?? '').toLocaleDateString()}
             </span>
-            {typeof r.usersConnected === 'number' && r.usersConnected > 0 && (
-              <span className="text-xs text-white/50">{r.usersConnected} online</span>
-            )}
+            <RoomAvatarStack id={r.id} />
             <span
               className="text-[10px] text-white/40 cursor-pointer select-none"
               onClick={e => { e.stopPropagation(); setRevealIds(prev => ({ ...prev, [r.id]: !prev[r.id] })) }}


### PR DESCRIPTION
## Summary
- show live avatars for each room on the selection pages
- make avatar initials unselectable

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888dcfc569c832e87bb56158761e350