### PR TITLE
Display avatars at right of room card

### DIFF
--- a/components/rooms/RoomAvatarStack.tsx
+++ b/components/rooms/RoomAvatarStack.tsx
@@ -21,7 +21,7 @@ export default function RoomAvatarStack({ id }: { id: string }) {
         }}
       >
         <ClientSideSuspense fallback={null}>
-          <LiveAvatarStack className="flex flex-row-reverse gap-1" size={20} />
+          <LiveAvatarStack className="absolute right-2 top-1/2 -translate-y-1/2 flex flex-row-reverse gap-1" size={20} />
         </ClientSideSuspense>
       </RoomProvider>
     </LiveblocksProvider>

--- a/components/rooms/RoomList.tsx
+++ b/components/rooms/RoomList.tsx
@@ -114,7 +114,7 @@ export default function RoomList({ onSelect, selectedId, onCreateClick }: Props)
         {rooms.map(r => (
           <div
             key={r.id}
-            className={`p-3 rounded-lg cursor-pointer flex flex-col gap-1 ${selectedId===r.id ? 'ring-2 ring-emerald-400/90 shadow-[0_0_12px_2px_rgba(16,185,129,0.6)]' : 'bg-black/30 hover:ring-2 hover:ring-emerald-300/40'}`}
+            className={`relative p-3 rounded-lg cursor-pointer flex flex-col gap-1 ${selectedId===r.id ? 'ring-2 ring-emerald-400/90 shadow-[0_0_12px_2px_rgba(16,185,129,0.6)]' : 'bg-black/30 hover:ring-2 hover:ring-emerald-300/40'}`}
             onClick={() => joinRoom(r)}
           >
             <div className="flex justify-between items-center gap-1">


### PR DESCRIPTION
## Summary
- keep room avatar stack centered vertically at card right
- make room card positioning relative

## Testing
- `npx next lint`

------
https://chatgpt.com/codex/tasks/task_e_6888e9e8f6b0832e9a55257388b2f6bc