### PR TITLE
Implement page deletion with storage update

### DIFF
--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { ReactNode } from "react";
 import { LiveblocksProvider, RoomProvider, ClientSideSuspense } from "@liveblocks/react/suspense";
+import { useStorage } from '@liveblocks/react'
 import { LiveMap, LiveObject, LiveList } from '@liveblocks/client'
 
 export function Room({ id, children }: { id: string; children: ReactNode }) {
@@ -30,9 +31,23 @@ export function Room({ id, children }: { id: string; children: ReactNode }) {
         }}
       >
         <ClientSideSuspense fallback={<div>Loading…</div>}>
-          {children}
+          <StorageSync>{children}</StorageSync>
         </ClientSideSuspense>
       </RoomProvider>
     </LiveblocksProvider>
   );
+}
+
+function StorageSync({ children }: { children: ReactNode }) {
+  const pages = useStorage(root => root.pages)
+  const currentPageId = useStorage(root => root.currentPageId)
+  const current = pages?.find(p => p.id === currentPageId)
+  return (
+    <LiveblocksProvider
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {...({ storage: { editor: current, pages }, allowNesting: true } as any)}
+    >
+      {children}
+    </LiveblocksProvider>
+  )
 }

--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { ReactNode } from "react";
 import { LiveblocksProvider, RoomProvider, ClientSideSuspense } from "@liveblocks/react/suspense";
-import { useStorage } from '@liveblocks/react'
+import { useStorage, useClient } from '@liveblocks/react'
 import { LiveMap, LiveObject, LiveList } from '@liveblocks/client'
 
 export function Room({ id, children }: { id: string; children: ReactNode }) {
@@ -39,14 +39,12 @@ export function Room({ id, children }: { id: string; children: ReactNode }) {
 }
 
 function StorageSync({ children }: { children: ReactNode }) {
+  const client = useClient()
   const pages = useStorage(root => root.pages)
   const currentPageId = useStorage(root => root.currentPageId)
   const current = pages?.find(p => p.id === currentPageId)
   return (
-    <LiveblocksProvider
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      {...({ storage: { editor: current, pages }, allowNesting: true } as any)}
-    >
+    <LiveblocksProvider client={client} storage={{ editor: current, pages }} allowNesting>
       {children}
     </LiveblocksProvider>
   )

--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -23,6 +23,8 @@ export function Room({ id, children }: { id: string; children: ReactNode }) {
           music: new LiveObject({ id: '', playing: false }),
           summary: new LiveObject({ acts: [] }),
           editor: '',
+          pages: new LiveList([]),
+          currentPageId: '',
           events: new LiveList([]),
           rooms: new LiveList([])
         }}

--- a/components/chat/SessionSummary.tsx
+++ b/components/chat/SessionSummary.tsx
@@ -44,8 +44,7 @@ const SessionSummary: FC<Props> = ({ onClose }) => {
   const fileBtnRef = useRef<HTMLButtonElement>(null)
 
   const updatePages = useMutation(({ storage }, acts: Page[]) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    storage.set('pages', new LiveList(acts as any))
+    storage.set('pages', new LiveList<Page>(acts))
   }, [])
 
   const updateEditor = useMutation(({ storage }, content: string) => {

--- a/components/chat/SessionSummary.tsx
+++ b/components/chat/SessionSummary.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { FC, useEffect, useState, useRef } from 'react'
 import { useStorage, useMutation } from '@liveblocks/react'
-import { LiveList } from '@liveblocks/client'
+import { LiveList, LsonObject } from '@liveblocks/client'
 import { LexicalComposer } from '@lexical/react/LexicalComposer'
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin'
 import { ContentEditable } from '@lexical/react/LexicalContentEditable'
@@ -10,7 +10,7 @@ import { LiveblocksPlugin, Toolbar, liveblocksConfig } from '@liveblocks/react-l
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import { $getRoot } from 'lexical'
 
-interface Page {
+interface Page extends LsonObject {
   id: string
   title: string
   content: string
@@ -44,12 +44,12 @@ const SessionSummary: FC<Props> = ({ onClose }) => {
   const fileBtnRef = useRef<HTMLButtonElement>(null)
 
   const updatePages = useMutation(({ storage }, acts: Page[]) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     storage.set('pages', new LiveList(acts as any))
   }, [])
 
   const updateEditor = useMutation(({ storage }, content: string) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    storage.set('editor', content as any)
+    storage.set('editor', content)
   }, [])
 
   useEffect(() => {
@@ -150,7 +150,7 @@ const SessionSummary: FC<Props> = ({ onClose }) => {
         <select value={currentId} onChange={e => { const id=e.target.value; setCurrentId(id); setStorageCurrent(id); setEditorKey(k => k + 1) }} className="bg-black/40 text-white rounded px-2 py-1 text-sm w-32">
           {pages?.map(p => <option key={p.id} value={p.id}>{p.title}</option>)}
         </select>
-        <button onClick={handleDelete} className="bg-black/40 text-white px-2 py-1 rounded text-sm">🗑️</button>
+        <button onClick={handleDelete} disabled={!pages || pages.length <= 1} className="bg-black/40 text-white px-2 py-1 rounded text-sm disabled:opacity-50">🗑️</button>
         <div className="relative">
           <button ref={fileBtnRef} onClick={() => setShowFileMenu(m => !m)} className="bg-black/40 text-white px-2 py-1 rounded text-sm">📁</button>
           {showFileMenu && (

--- a/components/rooms/RoomAvatarStack.tsx
+++ b/components/rooms/RoomAvatarStack.tsx
@@ -17,6 +17,8 @@ export default function RoomAvatarStack({ id }: { id: string }) {
           music: new LiveObject({ id: '', playing: false }),
           summary: new LiveObject({ acts: [] }),
           editor: '',
+          pages: new LiveList([]),
+          currentPageId: '',
           events: new LiveList([]),
           rooms: new LiveList([])
         }}

--- a/liveblocks.config.ts
+++ b/liveblocks.config.ts
@@ -53,6 +53,8 @@ declare global {
       music: LiveObject<{ id: string; playing: boolean }>;
       summary: LiveObject<{ acts: Array<{ id: string; title: string; content: string }> }>;
       editor: string;
+      pages: LiveList<{ id: string; title: string; content: string }>;
+      currentPageId: string;
       events: LiveList<SessionEvent>;
       rooms: LiveList<Room>;
     };


### PR DESCRIPTION
## Summary
- add `pages` and `currentPageId` to Liveblocks storage
- ensure initial storage includes those keys
- handle page deletion and selection updates in `SessionSummary`

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68893918d214832e8a07e186e2ce9890