### PR TITLE
Translate UI to English

### DIFF
--- a/components/character/AddCompetenceModal.tsx
+++ b/components/character/AddCompetenceModal.tsx
@@ -60,15 +60,15 @@ export const AddCompetenceModal: React.FC<AddCompetenceModalProps> = ({
                 >
                     ✕
                 </button>
-                <div className="text-lg font-semibold mb-4">Ajouter une compétence</div>
+                <div className="text-lg font-semibold mb-4">Add skill</div>
                 <div className="flex flex-col gap-3">
                     <div>
-                        <label className="block text-sm mb-1">Nom</label>
+                        <label className="block text-sm mb-1">Name</label>
                         <input
                             className="w-full px-2 py-1 rounded bg-gray-800 text-white"
                             value={nom}
                             onChange={e => setNom(e.target.value)}
-                            placeholder="Nom de la compétence"
+                            placeholder="Skill name"
                         />
                     </div>
                     <div>
@@ -84,16 +84,16 @@ export const AddCompetenceModal: React.FC<AddCompetenceModalProps> = ({
                         </select>
                     </div>
                     <div>
-                        <label className="block text-sm mb-1">Effets</label>
+                        <label className="block text-sm mb-1">Effects</label>
                         <input
                             className="w-full px-2 py-1 rounded bg-gray-800 text-white"
                             value={effets}
                             onChange={e => setEffets(e.target.value)}
-                            placeholder="Description des effets"
+                            placeholder="Effect description"
                         />
                     </div>
                     <div>
-                        <label className="block text-sm mb-1">Dégâts (optionnel)</label>
+                        <label className="block text-sm mb-1">Damage (optional)</label>
                         <input
                             className="w-full px-2 py-1 rounded bg-gray-800 text-white"
                             value={degats}
@@ -107,14 +107,14 @@ export const AddCompetenceModal: React.FC<AddCompetenceModalProps> = ({
                         className="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1"
                         onClick={onClose}
                     >
-                        Annuler
+                        Cancel
                     </button>
                     <button
                         className="bg-blue-600 hover:bg-blue-700 text-white rounded px-3 py-1"
                         onClick={handleAdd}
                         disabled={!nom || !type || !effets}
                     >
-                        Ajouter
+                        Add
                     </button>
                 </div>
             </div>

--- a/components/character/CharacterSheetHeader.tsx
+++ b/components/character/CharacterSheetHeader.tsx
@@ -66,7 +66,7 @@ const CharacterSheetHeader: FC<Props> = ({
           `}
           style={{ minHeight: 38 }}
         >
-          {edit ? 'Sauver' : 'Éditer'}
+          {edit ? 'Save' : 'Edit'}
         </button>
       </div>
       <nav className="flex gap-2 mt-2">

--- a/components/character/CompetencesPanel.tsx
+++ b/components/character/CompetencesPanel.tsx
@@ -17,19 +17,19 @@ const CompetencesPanel: FC<Props> = ({ competences = [], edit, onAdd, onDelete }
 
   return (
     <div className="mt-4">
-      <div className="font-semibold text-base mb-1">Compétences</div>
+      <div className="font-semibold text-base mb-1">Skills</div>
       {edit ? (
         <>
           <div className="flex flex-col gap-2 mb-2">
             {competences.map((c, i) => (
               <div key={i} className="bg-gray-800 rounded px-2 py-1 flex flex-col relative">
                 <div className="font-semibold">{c.nom} <span className="text-xs italic text-gray-300">({c.type})</span></div>
-                <div className="text-xs">Effets : {c.effets} {c.degats && <span>- Dégâts : {c.degats}</span>}</div>
-                <button className="absolute top-1 right-2 text-xs text-red-400 hover:underline" onClick={() => onDelete(i)}>Suppr</button>
+                <div className="text-xs">Effects: {c.effets} {c.degats && <span>- Damage: {c.degats}</span>}</div>
+                <button className="absolute top-1 right-2 text-xs text-red-400 hover:underline" onClick={() => onDelete(i)}>Delete</button>
               </div>
             ))}
           </div>
-          {/* Modal d’ajout */}
+          {/* Add skill modal */}
           <AddCompetenceModal
             open={showCompModal}
             onClose={() => setShowCompModal(false)}
@@ -39,7 +39,7 @@ const CompetencesPanel: FC<Props> = ({ competences = [], edit, onAdd, onDelete }
             className="bg-blue-600 hover:bg-blue-700 text-white text-sm rounded px-2 py-1"
             onClick={() => setShowCompModal(true)}
           >
-            Ajouter une compétence
+            Add skill
           </button>
         </>
       ) : (
@@ -47,7 +47,7 @@ const CompetencesPanel: FC<Props> = ({ competences = [], edit, onAdd, onDelete }
           {competences.map((c, i) => (
             <div key={i} className="bg-gray-800 rounded px-2 py-1">
               <div className="font-semibold">{c.nom} <span className="text-xs italic text-gray-300">({c.type})</span></div>
-              <div className="text-xs">Effets : {c.effets} {c.degats && <span>- Dégâts : {c.degats}</span>}</div>
+              <div className="text-xs">Effects: {c.effets} {c.degats && <span>- Damage: {c.degats}</span>}</div>
             </div>
           ))}
           {competences.length === 0 && <span className="text-gray-400 text-xs">No skill.</span>}

--- a/components/character/DescriptionPanel.tsx
+++ b/components/character/DescriptionPanel.tsx
@@ -75,19 +75,19 @@ const DescriptionPanel: FC<DescriptionPanelProps> = ({
   // Champs standards
   const shortFields = [
     { key: 'race', label: 'Race' },
-    { key: 'classe', label: 'Classe' },
-    { key: 'sexe', label: 'Sexe' },
-    { key: 'age', label: 'Âge' },
-    { key: 'taille', label: 'Taille' },
-    { key: 'poids', label: 'Poids' },
-    { key: 'bourse', label: 'Bourse (PA)' },
+    { key: 'classe', label: 'Class' },
+    { key: 'sexe', label: 'Gender' },
+    { key: 'age', label: 'Age' },
+    { key: 'taille', label: 'Height' },
+    { key: 'poids', label: 'Weight' },
+    { key: 'bourse', label: 'Purse (gp)' },
   ]
   const longFields = [
-    { key: 'traits', label: 'Trait perso' },
-    { key: 'ideal', label: 'Idéal' },
-    { key: 'obligations', label: 'Obligations' },
-    { key: 'failles', label: 'Failles' },
-    { key: 'avantages', label: 'Avantages' },
+    { key: 'traits', label: 'Traits' },
+    { key: 'ideal', label: 'Ideal' },
+    { key: 'obligations', label: 'Bonds' },
+    { key: 'failles', label: 'Flaws' },
+    { key: 'avantages', label: 'Features' },
     { key: 'background', label: 'Background' }
   ]
 
@@ -121,13 +121,13 @@ const DescriptionPanel: FC<DescriptionPanelProps> = ({
         </div>
       ))}
 
-      {/* Capacité raciale alignée */}
+      {/* Racial ability */}
       <div className="grid grid-cols-[120px_18px_1fr] mb-2 items-start">
         <label
           className="font-semibold text-right select-none"
           style={{ minWidth: LABEL_WIDTH }}
         >
-          Capacité raciale
+          Racial ability
         </label>
         <span className="text-right font-bold">:</span>
         <div className="flex-1 min-w-0 break-words pl-3">
@@ -144,7 +144,7 @@ const DescriptionPanel: FC<DescriptionPanelProps> = ({
         </div>
       </div>
 
-      {/* Champs longs (voir plus) alignés */}
+      {/* Long fields (see more) */}
       {longFields.map(({ key, label }) => (
         <div key={key} className="grid grid-cols-[120px_18px_1fr] mb-2 items-start">
           <label
@@ -171,7 +171,7 @@ const DescriptionPanel: FC<DescriptionPanelProps> = ({
 
       {/* Champs persos dynamiques */}
       <div className="mt-2">
-        <div className="font-semibold text-base mb-1">Autres champs</div>
+        <div className="font-semibold text-base mb-1">Custom fields</div>
         {edit ? (
           <>
             <div className="flex flex-col gap-1 mb-1">
@@ -193,7 +193,7 @@ const DescriptionPanel: FC<DescriptionPanelProps> = ({
                     }}
                     style={{ overflowWrap: 'break-word', minWidth: 0 }}
                   />
-                  <button className="text-xs text-red-400 hover:underline col-span-1 justify-self-end" onClick={() => onDelChamp(i)}>Suppr</button>
+                  <button className="text-xs text-red-400 hover:underline col-span-1 justify-self-end" onClick={() => onDelChamp(i)}>Delete</button>
                 </div>
               ))}
             </div>
@@ -201,14 +201,14 @@ const DescriptionPanel: FC<DescriptionPanelProps> = ({
               <div className="grid grid-cols-[120px_18px_1fr_80px] gap-1 w-full">
                 <input
                   className="p-1 rounded bg-white text-black text-sm w-full text-right"
-                  placeholder="Nom du champ"
+                  placeholder="Field name"
                   value={newChamp.label || ''}
                   onChange={e => setNewChamp({ ...newChamp, label: e.target.value })}
                 />
                 <span className="text-right font-bold">:</span>
                 <textarea
                   className="p-1 rounded bg-white text-black text-sm flex-1 min-h-[28px] resize-y w-full pl-3"
-                  placeholder="Valeur"
+                  placeholder="Value"
                   value={newChamp.value || ''}
                   onChange={e => setNewChamp({ ...newChamp, value: e.target.value })}
                   style={{ overflowWrap: 'break-word', minWidth: 0 }}
@@ -223,7 +223,7 @@ const DescriptionPanel: FC<DescriptionPanelProps> = ({
                   setNewChamp({})
                 }}
               >
-                Ajouter
+                Add
               </button>
             </div>
           </>

--- a/components/character/EquipPanel.tsx
+++ b/components/character/EquipPanel.tsx
@@ -40,36 +40,36 @@ const EquipPanel: FC<Props> = ({
 
   return (
     <div className="text-[1.07rem]">
-      <div className="font-semibold mb-2 text-lg">Armes & Armures</div>
+      <div className="font-semibold mb-2 text-lg">Weapons & Armor</div>
       <div className="mb-1 flex items-center">
-        <strong className="w-32">Armes :</strong>
+        <strong className="w-32">Weapons:</strong>
         {edit
           ? <input value={armes || ''} onChange={e => onChange('armes', e.target.value)} className="ml-1 px-1 py-0.5 rounded bg-white border w-28 text-sm text-black" />
           : <span className="ml-1">{armes}</span>
         }
       </div>
       <div className="mb-1 flex items-center">
-        <strong className="w-32">Dégâts armes :</strong>
+        <strong className="w-32">Weapon damage:</strong>
         {edit
           ? <input value={degats_armes || ''} onChange={e => onChange('degats_armes', e.target.value)} className="ml-1 px-1 py-0.5 rounded bg-white border w-20 text-sm text-black" />
           : <span className="ml-1">{degats_armes}</span>
         }
       </div>
       <div className="mb-1 flex items-center">
-        <strong className="w-32">Armure :</strong>
+        <strong className="w-32">Armor:</strong>
         {edit
           ? <input value={armure || ''} onChange={e => onChange('armure', e.target.value)} className="ml-1 px-1 py-0.5 rounded bg-white border w-28 text-sm text-black" />
           : <span className="ml-1">{armure}</span>
         }
       </div>
       <div className="mb-3 flex items-center">
-        <strong className="w-32">Modif armure :</strong>
+        <strong className="w-32">Armor mod:</strong>
         {edit
           ? <input type="number" value={modif_armure ?? ''} onChange={e => onChange('modif_armure', e.target.value)} className="ml-1 px-1 py-0.5 rounded bg-white border w-12 text-sm text-black" />
           : <span className="ml-1">{modif_armure}</span>
         }
       </div>
-      <div className="font-semibold text-lg mb-1 mt-3">Objets</div>
+      <div className="font-semibold text-lg mb-1 mt-3">Items</div>
       {/* Création/édition d’objets */}
       {edit ? (
         <>
@@ -78,20 +78,20 @@ const EquipPanel: FC<Props> = ({
               <div key={i} className="flex items-center gap-2 bg-gray-800 rounded px-2 py-1">
                 <span className="text-base">{o.nom}</span>
                 <span className="text-xs text-gray-300">x{o.quantite}</span>
-                <button className="text-xs text-red-400 hover:underline ml-2" onClick={() => onDelObj(i)}>Suppr</button>
+                <button className="text-xs text-red-400 hover:underline ml-2" onClick={() => onDelObj(i)}>Delete</button>
               </div>
             ))}
           </div>
           <div className="flex gap-1 mb-2">
             <input
               className="p-1 rounded bg-white text-black text-sm flex-1"
-              placeholder="Nom de l'objet"
+              placeholder="Item name"
               value={newObj.nom}
               onChange={e => setNewObj({ ...newObj, nom: e.target.value })}
             />
             <input
               className="p-1 rounded bg-white text-black text-sm w-16"
-              placeholder="Qté"
+              placeholder="Qty"
               type="number"
               min="1"
               value={newObj.quantite}
@@ -101,7 +101,7 @@ const EquipPanel: FC<Props> = ({
               className="bg-blue-600 hover:bg-blue-700 text-white text-sm rounded p-1"
               onClick={handleAddObj}
             >
-              Ajouter
+              Add
             </button>
           </div>
         </>

--- a/components/character/ImportExportMenu.tsx
+++ b/components/character/ImportExportMenu.tsx
@@ -148,9 +148,9 @@ const ImportExportMenu: FC<Props> = ({ perso, onUpdate }) => {
     setModal(null)
   }
 
-  // Reset fiche
+  // Reset sheet
   const handleReset = () => {
-    if (window.confirm("Vraiment réinitialiser la fiche ? (Suppression irréversible)")) {
+    if (window.confirm("Really reset the sheet? (This will delete it)")) {
       onUpdate({ ...defaultPerso })
       setOpen(false)
     }

--- a/components/character/StatsPanel.tsx
+++ b/components/character/StatsPanel.tsx
@@ -2,17 +2,17 @@ import { FC } from 'react'
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 const STATS = [
-  { key: 'force', label: 'Force' },
-  { key: 'dexterite', label: 'Dextérité' },
+  { key: 'force', label: 'Strength' },
+  { key: 'dexterite', label: 'Dexterity' },
   { key: 'constitution', label: 'Constitution' },
   { key: 'intelligence', label: 'Intelligence' },
-  { key: 'sagesse', label: 'Sagesse' },
-  { key: 'charisme', label: 'Charisme' }
+  { key: 'sagesse', label: 'Wisdom' },
+  { key: 'charisme', label: 'Charisma' }
 ]
 const ATTACKS = [
-  { key: 'mod_contact', label: 'Contact' },
-  { key: 'mod_distance', label: 'Distance' },
-  { key: 'mod_magique', label: 'Magique' }
+  { key: 'mod_contact', label: 'Melee' },
+  { key: 'mod_distance', label: 'Ranged' },
+  { key: 'mod_magique', label: 'Magic' }
 ]
 
 const getStatColor = (value: number) => {
@@ -43,32 +43,32 @@ const StatsPanel: FC<Props> = ({ edit, perso, onChange }) => {
 
   return (
     <div>
-      {/* Nom en haut à droite au-dessus des PV */}
+      {/* Name top right above HP */}
       <div className="flex justify-between items-start mb-2">
         <div className="flex flex-col gap-2 flex-1">
           <div className="flex items-center">
-            <strong className="w-20">Niveau :</strong>
+            <strong className="w-20">Level:</strong>
             {edit
               ? <input type="text" value={perso.niveau || ''} onChange={e => onChange('niveau', e.target.value)} className="ml-1 px-1 py-0.5 rounded bg-white border w-14 text-sm text-black" />
               : <span className="ml-1 text-sm">{perso.niveau}</span>
             }
           </div>
           <div className="flex items-center">
-            <strong className="w-20">Défense :</strong>
+            <strong className="w-20">Defense:</strong>
             {edit
               ? <input type="text" value={perso.defense || ''} onChange={e => onChange('defense', e.target.value)} className="ml-1 px-1 py-0.5 rounded bg-white border w-14 text-sm text-black" />
               : <span className="ml-1 text-sm">{perso.defense}</span>
             }
           </div>
           <div className="flex items-center">
-            <strong className="w-20">Chance :</strong>
+            <strong className="w-20">Luck:</strong>
             {edit
               ? <input type="text" value={perso.chance || ''} onChange={e => onChange('chance', e.target.value)} className="ml-1 px-1 py-0.5 rounded bg-white border w-14 text-sm text-black" />
               : <span className="ml-1 text-sm">{perso.chance}</span>
             }
           </div>
           <div className="flex items-center">
-            <strong className="w-20">Initiative :</strong>
+            <strong className="w-20">Initiative:</strong>
             {edit
               ? <input type="text" value={perso.initiative || ''} onChange={e => onChange('initiative', e.target.value)} className="ml-1 px-1 py-0.5 rounded bg-white border w-14 text-sm text-black" />
               : <span className="ml-1 text-sm">{perso.initiative}</span>
@@ -77,7 +77,7 @@ const StatsPanel: FC<Props> = ({ edit, perso, onChange }) => {
         </div>
         <div className="flex flex-col items-center ml-4">
           <div className="flex items-center mb-1">
-            <span className="text-sm text-gray-400 mr-2">Nom :</span>
+            <span className="text-sm text-gray-400 mr-2">Name:</span>
             {edit
               ? <input value={perso.nom || ''} onChange={e => onChange('nom', e.target.value)} className="px-1 py-0.5 rounded text-sm font-semibold bg-white border text-black w-[90px]" />
               : <span className="text-sm font-semibold">{perso.nom}</span>
@@ -86,7 +86,7 @@ const StatsPanel: FC<Props> = ({ edit, perso, onChange }) => {
           <span className={`flex items-center justify-center text-2xl font-bold rounded-full h-14 w-14 border-4 ${getPvColor(pvActuel, pvMax)}`} style={{ boxShadow: '0 0 8px #222' }}>
             {pvActuel}
           </span>
-          <span className="mt-1 text-xs text-gray-300">PV / {pvMax}</span>
+          <span className="mt-1 text-xs text-gray-300">HP / {pvMax}</span>
           {edit && (
             <div className="mt-1 flex gap-1">
               <input
@@ -95,7 +95,7 @@ const StatsPanel: FC<Props> = ({ edit, perso, onChange }) => {
                 value={perso.pv ?? ''}
                 onChange={e => onChange('pv', e.target.value)}
                 className="w-10 px-1 py-0.5 rounded bg-white border text-sm text-black"
-                placeholder="PV"
+                placeholder="HP"
               />
               <span className="text-gray-400 font-bold">/</span>
               <input
@@ -111,10 +111,10 @@ const StatsPanel: FC<Props> = ({ edit, perso, onChange }) => {
         </div>
       </div>
 
-      {/* Stats + attaques alignées */}
+      {/* Stats and attack modifiers */}
       <div className="mt-2 flex gap-0">
         <div className="flex-1">
-          <div className="font-semibold text-base mb-1">Caractéristiques</div>
+          <div className="font-semibold text-base mb-1">Attributes</div>
 {STATS.map(stat =>
   <div key={stat.key} className="flex gap-3 items-center mb-1">
     <strong className="w-28 text-right">{stat.label} :</strong>
@@ -127,13 +127,13 @@ const StatsPanel: FC<Props> = ({ edit, perso, onChange }) => {
       : <>
           <span
             className={`ml-2 px-2 py-0.5 rounded text-base font-bold ${getStatColor(Number(perso[stat.key]))} bg-opacity-80`}
-            style={{ display: 'inline-block', width: '36px', textAlign: 'center' }} // largeur fixée ici
+            style={{ display: 'inline-block', width: '36px', textAlign: 'center' }} // fixed width
           >
             {perso[stat.key]}
           </span>
           <span
             className="ml-2 text-gray-300 text-base font-semibold"
-            style={{ display: 'inline-block', width: '50px', textAlign: 'left' }} // largeur fixée pour tous les mods
+            style={{ display: 'inline-block', width: '50px', textAlign: 'left' }} // fixed width for all mods
           >
             ({perso[`${stat.key}_mod`] >= 0 ? '+' : ''}{perso[`${stat.key}_mod`]})
           </span>
@@ -144,7 +144,7 @@ const StatsPanel: FC<Props> = ({ edit, perso, onChange }) => {
 
         </div>
         <div className="flex flex-col items-end justify-between ml-4 min-w-[120px]">
-          <div className="font-semibold text-base mb-1">Mod. Attaques</div>
+          <div className="font-semibold text-base mb-1">Attack Mods</div>
           {ATTACKS.map(att =>
             <div key={att.key} className="flex items-center mb-2 w-full justify-end">
               <strong className="w-16 text-right">{att.label}</strong>

--- a/components/menu/CharacterModal.tsx
+++ b/components/menu/CharacterModal.tsx
@@ -67,32 +67,32 @@ const CharacterModal: FC<Props> = ({
         "
       >
         <h2 className="text-2xl font-bold mb-5 tracking-wide text-white text-center">
-          Édition du personnage
+          Character editing
         </h2>
         {/* Flex column: panels scrollent, boutons fixes en bas */}
         <div className="flex flex-col flex-1 min-h-0">
           <div
             className="flex flex-col lg:flex-row gap-5 flex-1 w-full min-h-0"
           >
-            {/* Statistiques */}
+            {/* Statistics */}
             <div
               className="flex-1 min-w-[260px] bg-white/5 rounded-xl p-4 flex flex-col"
               style={{ minWidth: 320, minHeight: 0, height: "100%", overflowY: "auto" }}
             >
               <h3 className="font-semibold text-lg mb-2 text-emerald-200">
-                Statistiques
+                Statistics
               </h3>
               <StatsPanel perso={character} edit={true} onChange={handlePanelChange} />
             </div>
-            {/* Équipement + Compétences dans la même colonne */}
+            {/* Equipment + Skills in the same column */}
             <div
               className="flex-1 min-w-[260px] bg-white/5 rounded-xl p-0 flex flex-col gap-3"
               style={{ minWidth: 320, minHeight: 0, height: "100%" }}
             >
-              {/* Équipement (moitié hauteur) */}
+              {/* Equipment (half height) */}
               <div className="flex-1 flex flex-col min-h-0 p-4 pb-2">
                 <h3 className="font-semibold text-lg mb-2 text-yellow-200">
-                  Équipement
+                  Equipment
                 </h3>
                 <EquipPanel
                   edit={true}
@@ -112,10 +112,10 @@ const CharacterModal: FC<Props> = ({
                   }}
                 />
               </div>
-              {/* Compétences (moitié hauteur) */}
+              {/* Skills (half height) */}
               <div className="flex-1 flex flex-col min-h-0 p-4 pt-0">
                 <h3 className="font-semibold text-lg mb-2 text-fuchsia-200">
-                  Compétences
+                  Skills
                 </h3>
                 <CompetencesPanel
                   competences={(character.competences as Competence[]) || []}
@@ -184,7 +184,7 @@ const CharacterModal: FC<Props> = ({
                 boxShadow: '0 2px 10px -2px #0006, 0 0 0 1px #fff2 inset'
               }}
             >
-              Annuler
+              Cancel
             </button>
             <button
               onClick={onSave}
@@ -201,7 +201,7 @@ const CharacterModal: FC<Props> = ({
                 boxShadow: '0 2px 16px 0 #1e3a8a22, 0 0 0 1.5px #27408155 inset'
               }}
             >
-              Sauvegarder
+              Save
             </button>
           </div>
         </div>

--- a/components/menu/MenuAccueil.tsx
+++ b/components/menu/MenuAccueil.tsx
@@ -224,8 +224,8 @@ export default function MenuAccueil() {
         saveCharacters([...characters, withId])
         localStorage.setItem(SELECTED_KEY, String(id))
         setSelectedIdx(characters.length)
-        alert('Fiche importée !')
-      } catch { alert('Erreur : fichier invalide.') }
+        alert('Sheet imported!')
+      } catch { alert('Error: invalid file.') }
     }
     reader.readAsText(file)
     e.target.value = ''

--- a/components/rooms/RoomList.tsx
+++ b/components/rooms/RoomList.tsx
@@ -46,7 +46,7 @@ export default function RoomList({ onSelect, selectedId, onCreateClick }: Props)
   }, [])
 
   const deleteRoom = async (room: RoomInfo) => {
-    if (!window.confirm('Supprimer cette room ?')) return
+    if (!window.confirm('Delete this room?')) return
     await fetch('/api/rooms', {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- translate labels and buttons from French to English
- adjust character creation fields and equipment panel
- rename modal headings and tooltips
- update reset prompt

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6889458db698832e91efe3256973e3ed