### PR TITLE
Implement new dice roll animation

### DIFF
--- a/components/dice/PopupResult.tsx
+++ b/components/dice/PopupResult.tsx
@@ -10,38 +10,41 @@ interface Props {
   onFinish?: () => void
 }
 
-const DiceFace: FC<{ value: string | number }> = ({ value }) => (
-  <motion.div
-    initial={{ scale: 0, rotate: 0, opacity: 0 }}
-    animate={{ scale: 1.2, rotate: 360, opacity: 1 }}
-    transition={{ duration: 0.6 }}
-    className="flex items-center justify-center w-32 h-32 text-black text-6xl font-extrabold rounded-2xl bg-white border-4 border-gray-400 shadow-xl select-none"
-  >
-    {value}
-  </motion.div>
-)
-
-const NeoDice3D: FC<Props> = ({ show, result, diceType, onFinish }) => {
+const PopupResult: FC<Props> = ({ show, result, diceType, onFinish }) => {
   const [visible, setVisible] = useState(false)
+  const [reveal, setReveal] = useState(false)
 
+  // When the parent requests the roll, display the dice
   useEffect(() => {
     if (show && result !== null) {
       setVisible(true)
-      const timeout = setTimeout(() => {
-        setVisible(false)
-        onFinish?.()
-      }, 3000) // dé visible 3s
-
-      return () => clearTimeout(timeout)
+      setReveal(false)
     }
-  }, [show, result, onFinish])
+  }, [show, result])
+
+  // After 3s of spinning, reveal the number
+  useEffect(() => {
+    if (!visible || reveal) return
+    const timer = setTimeout(() => setReveal(true), 3000)
+    return () => clearTimeout(timer)
+  }, [visible, reveal])
+
+  // Hide the dice shortly after the reveal and notify parent
+  useEffect(() => {
+    if (!reveal) return
+    const timer = setTimeout(() => {
+      setVisible(false)
+      onFinish?.()
+    }, 1500)
+    return () => clearTimeout(timer)
+  }, [reveal, onFinish])
 
   if (!visible || result === null) return null
 
   const isCrit = result === diceType
   const isFail = result === 1
 
-  const bgGlow = isCrit
+  const glow = isCrit
     ? 'shadow-[0_0_60px_rgba(253,224,71,0.8)]'
     : isFail
     ? 'shadow-[0_0_60px_rgba(239,68,68,0.8)]'
@@ -49,11 +52,50 @@ const NeoDice3D: FC<Props> = ({ show, result, diceType, onFinish }) => {
 
   return (
     <div className="fixed inset-0 flex items-center justify-center pointer-events-none z-[9999]">
-      <div className={`${bgGlow} rounded-2xl`}>
-        <DiceFace value={result} />
-      </div>
+      <motion.div
+        initial={false}
+        animate={
+          reveal
+            ? isFail
+              ? { rotateX: 0, rotateY: 0, rotateZ: 0, x: [0, -6, 6, -4, 4, -2, 2, 0], scale: [1.2, 1] }
+              : { rotateX: 0, rotateY: 0, rotateZ: 0, scale: [1.2, 1] }
+            : { rotateX: [0, 360, 720], rotateY: [0, 360, 720], rotateZ: [0, 360], scale: 1.2 }
+        }
+        transition={
+          reveal
+            ? { type: 'spring', stiffness: 200, damping: 12 }
+            : { duration: 3, ease: 'easeInOut' }
+        }
+        className={`${glow} flex items-center justify-center w-32 h-32 rounded-2xl bg-white border-4 border-gray-400 shadow-xl text-6xl font-extrabold select-none relative`}
+      >
+        {isCrit && reveal && (
+          <motion.div
+            className="absolute inset-0 rounded-2xl bg-yellow-300/40"
+            initial={{ opacity: 0.8, scale: 1 }}
+            animate={{ opacity: 0, scale: 1.6 }}
+            transition={{ duration: 0.8 }}
+          />
+        )}
+        {isFail && reveal && (
+          <motion.div
+            className="absolute inset-0 rounded-2xl bg-red-500/30"
+            initial={{ opacity: 0.8 }}
+            animate={{ opacity: 0 }}
+            transition={{ duration: 0.5 }}
+          />
+        )}
+        <motion.span
+          key={reveal ? 'result' : 'question'}
+          initial={{ rotateY: 0, opacity: 1 }}
+          animate={{ rotateY: [0, 90, 90, 0], opacity: [1, 0, 0, 1] }}
+          transition={{ duration: 0.6 }}
+          className="z-10"
+        >
+          {reveal ? result : '?'}
+        </motion.span>
+      </motion.div>
     </div>
   )
 }
 
-export default NeoDice3D
+export default PopupResult


### PR DESCRIPTION
## Summary
- replace `PopupResult` with a custom dice roll animation
- spin the dice for 3 seconds then reveal the result
- add critical and failure glow effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bd7d303f8832e949d061b96abb06a