### PR TITLE
Add animated 3D dice roll

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -67,3 +67,10 @@ body, .scrollable {
   background-color: rgba(250, 204, 21, 0.2);
   outline: 1px solid #facc15;
 }
+@keyframes dice-shake {
+  0%,100% { transform: translateX(0); }
+  25% { transform: translateX(-4px); }
+  50% { transform: translateX(4px); }
+  75% { transform: translateX(-2px); }
+}
+.shake { animation: dice-shake 0.6s ease-in-out; }

--- a/components/app/HomePageInner.tsx
+++ b/components/app/HomePageInner.tsx
@@ -7,7 +7,7 @@ import { useRouter, useParams } from 'next/navigation'
 import CharacterSheet, { defaultPerso } from '@/components/sheet/CharacterSheet'
 import DiceRoller from '@/components/dice/DiceRoller'
 import ChatBox from '@/components/chat/ChatBox'
-import PopupResult from '@/components/dice/PopupResult'
+import Dice3D from '@/components/dice/Dice3D'
 import Head from 'next/head'
 import InteractiveCanvas from '@/components/canvas/InteractiveCanvas'
 import LiveAvatarStack from '@/components/chat/LiveAvatarStack'
@@ -167,7 +167,7 @@ export default function HomePageInner() {
         <main className="flex-1 flex flex-col min-h-0">
           <div className="flex-1 m-4 flex flex-col justify-center items-center relative min-h-0">
             <InteractiveCanvas />
-            <PopupResult show={showPopup} result={diceResult} diceType={diceType} onFinish={handlePopupFinish} />
+            <Dice3D show={showPopup} result={diceResult} diceType={diceType} onFinish={handlePopupFinish} />
           </div>
           <DiceRoller diceType={diceType} onChange={setDiceType} onRoll={rollDice} disabled={diceDisabled}>
             <LiveAvatarStack />

--- a/components/chat/ChatBox.tsx
+++ b/components/chat/ChatBox.tsx
@@ -160,7 +160,7 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author }) => {
                   <><strong>{ev.author}{ev.isMJ && ' 👑'} :</strong> {ev.text}</>
                 )}
                 {ev.kind === 'dice' && (
-                  <span>{ev.player} : D{ev.dice} → {ev.result}</span>
+                  <span>{ev.player} lance un D{ev.dice} → {ev.result}</span>
                 )}
               </p>
             ))}

--- a/components/dice/Dice3D.tsx
+++ b/components/dice/Dice3D.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 
 const faceStyle =
-  'absolute w-full h-full flex items-center justify-center text-black text-4xl font-extrabold bg-white rounded-md select-none border border-gray-300'
+  'absolute w-full h-full flex items-center justify-center text-black text-4xl font-extrabold bg-white rounded-md select-none border border-gray-300 backface-hidden'
 
 const ORIENTATIONS = [
   { x: 0, y: 0, z: 0 }, // 1
@@ -29,16 +29,17 @@ const Dice3D: FC<Props> = ({ show, result, diceType, onFinish }) => {
     if (show && result !== null) {
       setVisible(true)
       setReveal(false)
+      controls.set({ rotateX: 45, rotateY: 45, rotateZ: 0 })
       let elapsed = 0
       const interval = setInterval(() => {
         controls.start({
-          rotateX: '+=' + (90 + Math.random() * 180),
-          rotateY: '+=' + (90 + Math.random() * 180),
-          rotateZ: '+=' + (90 + Math.random() * 180),
-          transition: { duration: 0.4, ease: 'easeInOut' },
+          rotateX: "+=" + (90 + Math.random() * 180),
+          rotateY: "+=" + (90 + Math.random() * 180),
+          rotateZ: "+=" + (90 + Math.random() * 180),
+          transition: { duration: 0.3, ease: 'easeInOut' },
         })
-        elapsed += 400
-        if (elapsed >= 2600) {
+        elapsed += 300
+        if (elapsed >= 2700) {
           clearInterval(interval)
           const idx = ((result - 1) % 6 + 6) % 6
           const final = ORIENTATIONS[idx]
@@ -57,7 +58,7 @@ const Dice3D: FC<Props> = ({ show, result, diceType, onFinish }) => {
               }, 1200)
             })
         }
-      }, 400)
+      }, 300)
       return () => clearInterval(interval)
     }
   }, [show, result, controls, onFinish])

--- a/components/dice/Dice3D.tsx
+++ b/components/dice/Dice3D.tsx
@@ -1,0 +1,108 @@
+import { FC, useEffect, useState } from 'react'
+import { motion, useAnimation } from 'framer-motion'
+
+interface Props {
+  show: boolean
+  result: number | null
+  diceType: number
+  onFinish?: () => void
+}
+
+const faceStyle =
+  'absolute w-full h-full flex items-center justify-center text-black text-4xl font-extrabold bg-white rounded-md select-none border border-gray-300'
+
+const ORIENTATIONS = [
+  { x: 0, y: 0, z: 0 }, // 1
+  { x: 0, y: -90, z: 0 }, // 2
+  { x: -90, y: 0, z: 0 }, // 3
+  { x: 90, y: 0, z: 0 }, // 4
+  { x: 0, y: 90, z: 0 }, // 5
+  { x: 0, y: 180, z: 0 }, // 6
+]
+
+const Dice3D: FC<Props> = ({ show, result, diceType, onFinish }) => {
+  const [visible, setVisible] = useState(false)
+  const [reveal, setReveal] = useState(false)
+  const controls = useAnimation()
+
+  useEffect(() => {
+    if (show && result !== null) {
+      setVisible(true)
+      setReveal(false)
+      let elapsed = 0
+      const interval = setInterval(() => {
+        controls.start({
+          rotateX: '+=' + (90 + Math.random() * 180),
+          rotateY: '+=' + (90 + Math.random() * 180),
+          rotateZ: '+=' + (90 + Math.random() * 180),
+          transition: { duration: 0.4, ease: 'easeInOut' },
+        })
+        elapsed += 400
+        if (elapsed >= 2600) {
+          clearInterval(interval)
+          const idx = ((result - 1) % 6 + 6) % 6
+          const final = ORIENTATIONS[idx]
+          controls
+            .start({
+              rotateX: final.x,
+              rotateY: final.y,
+              rotateZ: final.z,
+              transition: { duration: 0.6, ease: 'easeOut' },
+            })
+            .then(() => {
+              setReveal(true)
+              setTimeout(() => {
+                setVisible(false)
+                onFinish?.()
+              }, 1200)
+            })
+        }
+      }, 400)
+      return () => clearInterval(interval)
+    }
+  }, [show, result, controls, onFinish])
+
+  if (!visible || result === null) return null
+
+  const isCrit = result === diceType
+  const isFail = result === 1
+
+  const wrapperClass = isCrit
+    ? 'shadow-[0_0_60px_rgba(253,224,71,0.8)]'
+    : isFail
+    ? 'shadow-[0_0_60px_rgba(239,68,68,0.8)] shake'
+    : 'shadow-[0_0_40px_rgba(96,165,250,0.6)]'
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center pointer-events-none z-[9999]">
+      <div className={wrapperClass} style={{ perspective: 600 }}>
+        <motion.div
+          className="relative w-24 h-24"
+          style={{ transformStyle: 'preserve-3d' }}
+          animate={controls}
+        >
+          <div className="" style={{ transform: 'rotateY(0deg) translateZ(48px)' }}>
+            <div className={faceStyle}>{reveal ? result : '?'}</div>
+          </div>
+          <div style={{ transform: 'rotateY(180deg) translateZ(48px)' }}>
+            <div className={faceStyle}>?</div>
+          </div>
+          <div style={{ transform: 'rotateY(90deg) translateZ(48px)' }}>
+            <div className={faceStyle}>?</div>
+          </div>
+          <div style={{ transform: 'rotateY(-90deg) translateZ(48px)' }}>
+            <div className={faceStyle}>?</div>
+          </div>
+          <div style={{ transform: 'rotateX(90deg) translateZ(48px)' }}>
+            <div className={faceStyle}>?</div>
+          </div>
+          <div style={{ transform: 'rotateX(-90deg) translateZ(48px)' }}>
+            <div className={faceStyle}>?</div>
+          </div>
+        </motion.div>
+      </div>
+    </div>
+  )
+}
+
+export default Dice3D


### PR DESCRIPTION
## Summary
- add new `Dice3D` component for dice roll animation
- show result message in French in chat
- replace old popup with new 3D dice
- minor global CSS for shake effect

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bdb8e6f0c832ea10c9d7381212487