### PR TITLE
Preserve room metadata on rename

### DIFF
--- a/lib/liveRooms.ts
+++ b/lib/liveRooms.ts
@@ -79,5 +79,7 @@ export async function renameRoom(id: string, name: string) {
   const secret = process.env.LIVEBLOCKS_SECRET_KEY
   if (!secret) throw new Error('Liveblocks key missing')
   const client = new Liveblocks({ secret })
-  await client.updateRoom(id, { metadata: { name } })
+  const room = await client.getRoom(id)
+  const metadata = typeof room.metadata === 'object' && room.metadata !== null ? room.metadata : {}
+  await client.updateRoom(id, { metadata: { ...metadata, name } })
 }


### PR DESCRIPTION
## Summary
- keep existing room metadata when renaming to avoid stripping password or other fields

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f7076e8f4832ea38700912e60aabc