### PR TITLE
Implement dice roll cooldown and reliable result display

### DIFF
--- a/components/app/HomePageInner.tsx
+++ b/components/app/HomePageInner.tsx
@@ -160,7 +160,7 @@ export default function HomePageInner() {
         setDiceDisabled(false)
         setDiceResult(null)
       }, 1000)
-    }, 1000)
+    }, 2000)
   }
 
   return (

--- a/components/app/HomePageInner.tsx
+++ b/components/app/HomePageInner.tsx
@@ -36,6 +36,8 @@ export default function HomePageInner() {
   const { addEvent } = useEventLog(roomId)
   const chatBoxRef = useRef<HTMLDivElement>(null)
   const [cooldown, setCooldown] = useState(false)
+  // total durée d'indisponibilité du bouton (animation + hold + cooldown)
+  const ROLL_TOTAL_MS = 2000 + 300 + 2000 + 1000
 
   const broadcast = useBroadcastEvent()
   const [, updateMyPresence] = useMyPresence()
@@ -138,6 +140,7 @@ export default function HomePageInner() {
   const rollDice = () => {
     if (diceDisabled) return
     setDiceDisabled(true)
+    setCooldown(true)
     const result = Math.floor(Math.random() * diceType) + 1
     setDiceResult(result)
     setShowPopup(true)
@@ -152,15 +155,11 @@ export default function HomePageInner() {
     broadcast({ type: 'dice-roll', player: pendingRoll.nom, dice: pendingRoll.dice, result: pendingRoll.result } as Liveblocks['RoomEvent'])
     addEvent({ id: crypto.randomUUID(), kind: 'dice', player: pendingRoll.nom, dice: pendingRoll.dice, result: pendingRoll.result, ts: Date.now() })
     setPendingRoll(null)
-    // keep the result visible until the popup unmounts, then start the cooldown
     window.setTimeout(() => {
-      setCooldown(true)
-      window.setTimeout(() => {
-        setCooldown(false)
-        setDiceDisabled(false)
-        setDiceResult(null)
-      }, 1000)
-    }, 2000)
+      setCooldown(false)
+      setDiceDisabled(false)
+      setDiceResult(null)
+    }, 1000)
   }
 
   return (
@@ -179,7 +178,7 @@ export default function HomePageInner() {
             <InteractiveCanvas />
             <PopupResult show={showPopup} result={diceResult} diceType={diceType} onFinish={handlePopupFinish} />
           </div>
-          <DiceRoller diceType={diceType} onChange={setDiceType} onRoll={rollDice} disabled={diceDisabled} cooldown={cooldown}>
+          <DiceRoller diceType={diceType} onChange={setDiceType} onRoll={rollDice} disabled={diceDisabled} cooldown={cooldown} cooldownDuration={ROLL_TOTAL_MS}>
             <LiveAvatarStack />
           </DiceRoller>
         </main>

--- a/components/app/HomePageInner.tsx
+++ b/components/app/HomePageInner.tsx
@@ -147,14 +147,18 @@ export default function HomePageInner() {
     setPendingRoll({ result, dice: diceType, nom: perso.nom || '?' })
   }
 
+  const handlePopupReveal = () => {
+    if (!pendingRoll) return
+    const { nom, dice, result } = pendingRoll
+    const entry = { player: nom, dice, result, ts: Date.now() }
+    setHistory((h) => [...h, entry])
+    broadcast({ type: 'dice-roll', player: nom, dice, result } as Liveblocks['RoomEvent'])
+    addEvent({ id: crypto.randomUUID(), kind: 'dice', player: nom, dice, result, ts: entry.ts })
+    setPendingRoll(null)
+  }
+
   const handlePopupFinish = () => {
     setShowPopup(false)
-    if (!pendingRoll) return
-
-    setHistory((h) => [...h, { player: pendingRoll.nom, dice: pendingRoll.dice, result: pendingRoll.result, ts: Date.now() }])
-    broadcast({ type: 'dice-roll', player: pendingRoll.nom, dice: pendingRoll.dice, result: pendingRoll.result } as Liveblocks['RoomEvent'])
-    addEvent({ id: crypto.randomUUID(), kind: 'dice', player: pendingRoll.nom, dice: pendingRoll.dice, result: pendingRoll.result, ts: Date.now() })
-    setPendingRoll(null)
     window.setTimeout(() => {
       setCooldown(false)
       setDiceDisabled(false)
@@ -176,7 +180,7 @@ export default function HomePageInner() {
         <main className="flex-1 flex flex-col min-h-0">
           <div className="flex-1 m-4 flex flex-col justify-center items-center relative min-h-0">
             <InteractiveCanvas />
-            <PopupResult show={showPopup} result={diceResult} diceType={diceType} onFinish={handlePopupFinish} />
+            <PopupResult show={showPopup} result={diceResult} diceType={diceType} onReveal={handlePopupReveal} onFinish={handlePopupFinish} />
           </div>
           <DiceRoller diceType={diceType} onChange={setDiceType} onRoll={rollDice} disabled={diceDisabled} cooldown={cooldown} cooldownDuration={ROLL_TOTAL_MS}>
             <LiveAvatarStack />

--- a/components/app/HomePageInner.tsx
+++ b/components/app/HomePageInner.tsx
@@ -152,12 +152,13 @@ export default function HomePageInner() {
     broadcast({ type: 'dice-roll', player: pendingRoll.nom, dice: pendingRoll.dice, result: pendingRoll.result } as Liveblocks['RoomEvent'])
     addEvent({ id: crypto.randomUUID(), kind: 'dice', player: pendingRoll.nom, dice: pendingRoll.dice, result: pendingRoll.result, ts: Date.now() })
     setPendingRoll(null)
-    setDiceResult(null)
+    // keep the result visible until the popup unmounts, then start the cooldown
     window.setTimeout(() => {
       setCooldown(true)
       window.setTimeout(() => {
         setCooldown(false)
         setDiceDisabled(false)
+        setDiceResult(null)
       }, 1000)
     }, 1000)
   }

--- a/components/dice/DiceRoller.tsx
+++ b/components/dice/DiceRoller.tsx
@@ -44,11 +44,11 @@ const DiceRoller: FC<Props> = ({ diceType, onChange, onRoll, disabled, cooldown,
         <option key={val} value={val}>D{val}</option>
       ))}
     </select>
-    <div className="relative ml-4">
+    <div className="ml-4">
       <button
         onClick={onRoll}
         className={`
-          flex items-center gap-2
+          relative flex items-center gap-2
           px-7 py-2 rounded-2xl
           font-bold text-base
           text-white
@@ -68,15 +68,15 @@ const DiceRoller: FC<Props> = ({ diceType, onChange, onRoll, disabled, cooldown,
       >
         <Dice3 className="inline -mt-0.5 text-white/80" size={20} />
         {t('roll')}
+        {cooldown && (
+          <motion.span
+            className="absolute inset-0 rounded-2xl bg-black/40 origin-left pointer-events-none"
+            initial={{ scaleX: 1 }}
+            animate={{ scaleX: 0 }}
+            transition={{ duration: cooldownDuration / 1000, ease: 'linear' }}
+          />
+        )}
       </button>
-      {cooldown && (
-        <motion.div
-          className="absolute inset-0 rounded-2xl bg-black/40 origin-left pointer-events-none"
-          initial={{ scaleX: 1 }}
-          animate={{ scaleX: 0 }}
-          transition={{ duration: cooldownDuration / 1000, ease: 'linear' }}
-        />
-      )}
     </div>
     {children && <div className="ml-auto flex gap-1">{children}</div>}
   </div>

--- a/components/dice/DiceRoller.tsx
+++ b/components/dice/DiceRoller.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { FC } from 'react'
 import { Dice3 } from 'lucide-react'
+import { motion } from 'framer-motion'
 import { useT } from '@/lib/useT'
 
 type Props = {
@@ -8,10 +9,11 @@ type Props = {
   onChange: (value: number) => void
   onRoll: () => void
   disabled: boolean
+  cooldown: boolean
   children?: React.ReactNode
 }
 
-const DiceRoller: FC<Props> = ({ diceType, onChange, onRoll, disabled, children }) => {
+const DiceRoller: FC<Props> = ({ diceType, onChange, onRoll, disabled, cooldown, children }) => {
   const t = useT()
   return (
   <div
@@ -41,30 +43,40 @@ const DiceRoller: FC<Props> = ({ diceType, onChange, onRoll, disabled, children 
         <option key={val} value={val}>D{val}</option>
       ))}
     </select>
-    <button
-      onClick={onRoll}
-      className={`
-        ml-4 flex items-center gap-2
-        px-7 py-2 rounded-2xl
-        font-bold text-base
-        text-white
-        shadow
-        border border-white/10
-        bg-[#253053]/60
-        hover:bg-[#253053]/80
-        active:scale-95
-        transition
-        backdrop-blur-sm
-        ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
-      `}
-      style={{
-        boxShadow: '0 2px 12px 0 #1115'
-      }}
-      disabled={disabled}
-    >
-      <Dice3 className="inline -mt-0.5 text-white/80" size={20} />
-      {t('roll')}
-    </button>
+    <div className="relative">
+      <button
+        onClick={onRoll}
+        className={`
+          ml-4 flex items-center gap-2
+          px-7 py-2 rounded-2xl
+          font-bold text-base
+          text-white
+          shadow
+          border border-white/10
+          bg-[#253053]/60
+          hover:bg-[#253053]/80
+          active:scale-95
+          transition
+          backdrop-blur-sm
+          ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
+        `}
+        style={{
+          boxShadow: '0 2px 12px 0 #1115'
+        }}
+        disabled={disabled}
+      >
+        <Dice3 className="inline -mt-0.5 text-white/80" size={20} />
+        {t('roll')}
+      </button>
+      {cooldown && (
+        <motion.div
+          className="absolute inset-0 rounded-2xl bg-black/40 origin-left pointer-events-none"
+          initial={{ scaleX: 1 }}
+          animate={{ scaleX: 0 }}
+          transition={{ duration: 1, ease: 'linear' }}
+        />
+      )}
+    </div>
     {children && <div className="ml-auto flex gap-1">{children}</div>}
   </div>
   )

--- a/components/dice/DiceRoller.tsx
+++ b/components/dice/DiceRoller.tsx
@@ -10,10 +10,11 @@ type Props = {
   onRoll: () => void
   disabled: boolean
   cooldown: boolean
+  cooldownDuration: number
   children?: React.ReactNode
 }
 
-const DiceRoller: FC<Props> = ({ diceType, onChange, onRoll, disabled, cooldown, children }) => {
+const DiceRoller: FC<Props> = ({ diceType, onChange, onRoll, disabled, cooldown, cooldownDuration, children }) => {
   const t = useT()
   return (
   <div
@@ -43,11 +44,11 @@ const DiceRoller: FC<Props> = ({ diceType, onChange, onRoll, disabled, cooldown,
         <option key={val} value={val}>D{val}</option>
       ))}
     </select>
-    <div className="relative">
+    <div className="relative ml-4">
       <button
         onClick={onRoll}
         className={`
-          ml-4 flex items-center gap-2
+          flex items-center gap-2
           px-7 py-2 rounded-2xl
           font-bold text-base
           text-white
@@ -73,7 +74,7 @@ const DiceRoller: FC<Props> = ({ diceType, onChange, onRoll, disabled, cooldown,
           className="absolute inset-0 rounded-2xl bg-black/40 origin-left pointer-events-none"
           initial={{ scaleX: 1 }}
           animate={{ scaleX: 0 }}
-          transition={{ duration: 1, ease: 'linear' }}
+          transition={{ duration: cooldownDuration / 1000, ease: 'linear' }}
         />
       )}
     </div>

--- a/components/dice/PopupResult.tsx
+++ b/components/dice/PopupResult.tsx
@@ -9,12 +9,13 @@ interface Props {
   result: number | null
   diceType: number
   onFinish?: (result: number) => void
+  onReveal?: (result: number) => void
 }
 
 // Track alternance of spin patterns to vary animation
 let patternToggle = 0
 
-export default function PopupResult({ show, result, diceType, onFinish }: Props) {
+export default function PopupResult({ show, result, diceType, onFinish, onReveal }: Props) {
   const [visible,   setVisible]   = useState(false)
   const [faceIndex, setFaceIndex] = useState(0)
   const [spin,      setSpin]      = useState({ x: 0, y: 0 })
@@ -52,6 +53,7 @@ export default function PopupResult({ show, result, diceType, onFinish }: Props)
     const totalDelay = SPIN_DURATION + RESULT_DELAY
     const t1 = window.setTimeout(() => {
       setShowResult(true)
+      onReveal?.(result)
       // Hold un peu plus pour visualiser puis déclencher le callback
       window.setTimeout(() => {
         setVisible(false)
@@ -62,7 +64,7 @@ export default function PopupResult({ show, result, diceType, onFinish }: Props)
     return () => {
       window.clearTimeout(t1)
     }
-  }, [show, result, onFinish])
+  }, [show, result, onFinish, onReveal])
 
   if (!visible || result === null) return null
 

--- a/components/dice/PopupResult.tsx
+++ b/components/dice/PopupResult.tsx
@@ -11,16 +11,7 @@ interface Props {
   onFinish?: (result: number) => void
 }
 
-// Angles fixes pour aligner chaque face devant le joueur
-const faceRotations = [
-  { x:   0, y:   0 }, // front
-  { x:   0, y: 180 }, // back
-  { x:   0, y:  90 }, // left
-  { x:   0, y: -90 }, // right
-  { x: -90, y:   0 }, // top
-  { x:  90, y:   0 }, // bottom
-]
-
+// Track alternance of spin patterns to vary animation
 let patternToggle = 0
 
 export default function PopupResult({ show, result, diceType, onFinish }: Props) {
@@ -32,7 +23,7 @@ export default function PopupResult({ show, result, diceType, onFinish }: Props)
   // Durées (ms)
   const SPIN_DURATION = 2000      // durée de la rotation
   const RESULT_DELAY  = 300       // délai pour démarrer le fondu
-  const HOLD_DURATION = 1000      // temps avant de démonter après le fondu
+  const HOLD_DURATION = 2000      // temps avant de démonter après le fondu
 
   useEffect(() => {
     if (!show || result === null) return
@@ -40,20 +31,16 @@ export default function PopupResult({ show, result, diceType, onFinish }: Props)
     // reset
     setShowResult(false)
     setVisible(true)
-
-    // Choix aléatoire de la face finale
-    const idx = Math.floor(Math.random() * faceRotations.length)
-    setFaceIndex(idx)
+    setFaceIndex(0) // always finish on the front face
 
     // Alterner 2 ou 3 tours pour varier
     const toursX = 2 + (patternToggle % 2)
     const toursY = 2 + ((patternToggle + 1) % 2)
     patternToggle++
 
-    const base = faceRotations[idx]
     setSpin({
-      x: base.x + 360 * toursX,
-      y: base.y + 360 * toursY,
+      x: 360 * toursX,
+      y: 360 * toursY,
     })
 
     // Tant que la pop-up reste visible, on fera :
@@ -61,7 +48,7 @@ export default function PopupResult({ show, result, diceType, onFinish }: Props)
     // 2) attendre RESULT_DELAY
     // 3) showResult = true
     // 4) onFinish callback
-    // 5) laisser H OLD_DURATION avant setVisible(false)
+    // 5) laisser HOLD_DURATION avant setVisible(false)
     const totalDelay = SPIN_DURATION + RESULT_DELAY
     const t1 = window.setTimeout(() => {
       setShowResult(true)

--- a/components/dice/PopupResult.tsx
+++ b/components/dice/PopupResult.tsx
@@ -47,15 +47,15 @@ export default function PopupResult({ show, result, diceType, onFinish }: Props)
     // 1) rotation (SPIN_DURATION)
     // 2) attendre RESULT_DELAY
     // 3) showResult = true
-    // 4) onFinish callback
-    // 5) laisser HOLD_DURATION avant setVisible(false)
+    // 4) laisser HOLD_DURATION puis onFinish
+    // 5) setVisible(false)
     const totalDelay = SPIN_DURATION + RESULT_DELAY
     const t1 = window.setTimeout(() => {
       setShowResult(true)
-      onFinish?.(result)
-      // Hold un peu plus pour visualiser
+      // Hold un peu plus pour visualiser puis déclencher le callback
       window.setTimeout(() => {
         setVisible(false)
+        onFinish?.(result)
       }, HOLD_DURATION)
     }, totalDelay)
 

--- a/components/dice/PopupResult.tsx
+++ b/components/dice/PopupResult.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FC, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { motion } from 'framer-motion'
 import './popupresult.css'
 

--- a/components/dice/PopupResult.tsx
+++ b/components/dice/PopupResult.tsx
@@ -15,8 +15,8 @@ interface Props {
 const faceRotations = [
   { x:   0, y:   0 }, // front
   { x:   0, y: 180 }, // back
-  { x:   0, y: -90 }, // left
-  { x:   0, y:  90 }, // right
+  { x:   0, y:  90 }, // left
+  { x:   0, y: -90 }, // right
   { x: -90, y:   0 }, // top
   { x:  90, y:   0 }, // bottom
 ]


### PR DESCRIPTION
## Summary
- prevent dice rerolls until animation completes and add 1s cooldown
- show animated cooldown overlay on roll button
- clear dice result to avoid stuck '?' and satisfy lint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689127243894832ea38fad9ca4ab092f