### PR TITLE
Ensure dice result reveals after animation

### DIFF
--- a/components/dice/PopupResult.tsx
+++ b/components/dice/PopupResult.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { motion } from 'framer-motion'
 import './popupresult.css'
 
@@ -20,6 +20,18 @@ export default function PopupResult({ show, result, diceType, onFinish, onReveal
   const [faceIndex, setFaceIndex] = useState(0)
   const [spin,      setSpin]      = useState({ x: 0, y: 0 })
   const [showResult, setShowResult] = useState(false)
+
+  // stocker les callbacks dans des refs pour éviter de relancer l'animation
+  const finishRef = useRef<Props['onFinish']>()
+  const revealRef = useRef<Props['onReveal']>()
+
+  useEffect(() => {
+    finishRef.current = onFinish
+  }, [onFinish])
+
+  useEffect(() => {
+    revealRef.current = onReveal
+  }, [onReveal])
 
   // Durées (ms)
   const SPIN_DURATION = 2000      // durée de la rotation
@@ -53,18 +65,18 @@ export default function PopupResult({ show, result, diceType, onFinish, onReveal
     const totalDelay = SPIN_DURATION + RESULT_DELAY
     const t1 = window.setTimeout(() => {
       setShowResult(true)
-      onReveal?.(result)
+      revealRef.current?.(result)
       // Hold un peu plus pour visualiser puis déclencher le callback
       window.setTimeout(() => {
         setVisible(false)
-        onFinish?.(result)
+        finishRef.current?.(result)
       }, HOLD_DURATION)
     }, totalDelay)
 
     return () => {
       window.clearTimeout(t1)
     }
-  }, [show, result, onFinish, onReveal])
+  }, [show, result])
 
   if (!visible || result === null) return null
 

--- a/components/dice/PopupResult.tsx
+++ b/components/dice/PopupResult.tsx
@@ -22,8 +22,8 @@ export default function PopupResult({ show, result, diceType, onFinish, onReveal
   const [showResult, setShowResult] = useState(false)
 
   // stocker les callbacks dans des refs pour éviter de relancer l'animation
-  const finishRef = useRef<Props['onFinish']>()
-  const revealRef = useRef<Props['onReveal']>()
+  const finishRef = useRef<Props['onFinish'] | null>(null)
+  const revealRef = useRef<Props['onReveal'] | null>(null)
 
   useEffect(() => {
     finishRef.current = onFinish

--- a/components/dice/PopupResult.tsx
+++ b/components/dice/PopupResult.tsx
@@ -63,11 +63,12 @@ export default function PopupResult({ show, result, diceType, onFinish, onReveal
     // 4) laisser HOLD_DURATION puis onFinish
     // 5) setVisible(false)
     const totalDelay = SPIN_DURATION + RESULT_DELAY
+    let t2: number
     const t1 = window.setTimeout(() => {
       setShowResult(true)
       revealRef.current?.(result)
       // Hold un peu plus pour visualiser puis déclencher le callback
-      window.setTimeout(() => {
+      t2 = window.setTimeout(() => {
         setVisible(false)
         finishRef.current?.(result)
       }, HOLD_DURATION)
@@ -75,6 +76,7 @@ export default function PopupResult({ show, result, diceType, onFinish, onReveal
 
     return () => {
       window.clearTimeout(t1)
+      window.clearTimeout(t2)
     }
   }, [show, result])
 


### PR DESCRIPTION
## Summary
- Stabilize PopupResult timer by storing callbacks in refs
- Trigger result reveal using refs so rotation finishes reliably

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68936dd9d390832e85072e5c10abd41b