### PR TITLE
feat: add collapsible game panels

### DIFF
--- a/components/app/HomePageInner.tsx
+++ b/components/app/HomePageInner.tsx
@@ -11,7 +11,6 @@ import PopupResult from '@/components/dice/PopupResult'
 import Head from 'next/head'
 import InteractiveCanvas from '@/components/canvas/InteractiveCanvas'
 import LiveAvatarStack from '@/components/chat/LiveAvatarStack'
-import SideNotes from '@/components/misc/SideNotes'
 import Login from '@/components/login/Login'
 import GMCharacterSelector from '@/components/misc/GMCharacterSelector'
 import useDiceHistory from './hooks/useDiceHistory'
@@ -233,7 +232,6 @@ export default function HomePageInner() {
           collapsed={isChatCollapsed}
           onToggle={() => setChatCollapsed(c => !c)}
         />
-        <SideNotes />
       </div>
       <Head>
         <title>CakeJDR</title>

--- a/components/app/HomePageInner.tsx
+++ b/components/app/HomePageInner.tsx
@@ -39,6 +39,10 @@ export default function HomePageInner() {
   // total durée d'indisponibilité du bouton (animation + hold + cooldown)
   const ROLL_TOTAL_MS = 2000 + 300 + 2000 + 1000
 
+  const [isCharacterCollapsed, setCharacterCollapsed] = useState(false)
+  const [isChatCollapsed, setChatCollapsed] = useState(false)
+  const [isDiceCollapsed, setDiceCollapsed] = useState(false)
+
   const broadcast = useBroadcastEvent()
   const [, updateMyPresence] = useMyPresence()
 
@@ -62,6 +66,24 @@ export default function HomePageInner() {
     }
   })
 
+  useEffect(() => {
+    const char = localStorage.getItem('collapse_character')
+    const chat = localStorage.getItem('collapse_chat')
+    const dice = localStorage.getItem('collapse_dice')
+    if (char !== null) setCharacterCollapsed(char === 'true')
+    if (chat !== null) setChatCollapsed(chat === 'true')
+    if (dice !== null) setDiceCollapsed(dice === 'true')
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('collapse_character', String(isCharacterCollapsed))
+  }, [isCharacterCollapsed])
+  useEffect(() => {
+    localStorage.setItem('collapse_chat', String(isChatCollapsed))
+  }, [isChatCollapsed])
+  useEffect(() => {
+    localStorage.setItem('collapse_dice', String(isDiceCollapsed))
+  }, [isDiceCollapsed])
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -169,7 +191,15 @@ export default function HomePageInner() {
   return (
     <div className="relative w-screen h-screen font-sans overflow-hidden bg-transparent">
       <div className="relative z-10 flex flex-col lg:flex-row w-full h-full">
-        <CharacterSheet perso={perso} onUpdate={handleUpdatePerso} chatBoxRef={chatBoxRef} allCharacters={characters} logoOnly>
+        <CharacterSheet
+          perso={perso}
+          onUpdate={handleUpdatePerso}
+          chatBoxRef={chatBoxRef}
+          allCharacters={characters}
+          logoOnly
+          collapsed={isCharacterCollapsed}
+          onToggle={() => setCharacterCollapsed(c => !c)}
+        >
           {profile?.isMJ && (
             <span className="ml-2">
               <GMCharacterSelector onSelect={handleUpdatePerso} />
@@ -182,7 +212,16 @@ export default function HomePageInner() {
             <InteractiveCanvas />
             <PopupResult show={showPopup} result={diceResult} diceType={diceType} onReveal={handlePopupReveal} onFinish={handlePopupFinish} />
           </div>
-          <DiceRoller diceType={diceType} onChange={setDiceType} onRoll={rollDice} disabled={diceDisabled} cooldown={cooldown} cooldownDuration={ROLL_TOTAL_MS}>
+          <DiceRoller
+            diceType={diceType}
+            onChange={setDiceType}
+            onRoll={rollDice}
+            disabled={diceDisabled}
+            cooldown={cooldown}
+            cooldownDuration={ROLL_TOTAL_MS}
+            collapsed={isDiceCollapsed}
+            onToggle={() => setDiceCollapsed(c => !c)}
+          >
             <LiveAvatarStack />
           </DiceRoller>
         </main>
@@ -191,6 +230,8 @@ export default function HomePageInner() {
           chatBoxRef={chatBoxRef}
           history={history}
           author={perso.nom || profile?.pseudo || 'Anonymous'}
+          collapsed={isChatCollapsed}
+          onToggle={() => setChatCollapsed(c => !c)}
         />
         <SideNotes />
       </div>

--- a/components/canvas/InteractiveCanvas.tsx
+++ b/components/canvas/InteractiveCanvas.tsx
@@ -6,6 +6,7 @@ import LiveCursors from './LiveCursors'
 import YouTube from 'react-youtube'
 import type { YouTubePlayer } from 'youtube-player/dist/types'
 import CanvasTools, { ToolMode } from './CanvasTools'
+import SideNotes from '@/components/misc/SideNotes'
 import { useT } from '@/lib/useT'
 import MusicPanel from './MusicPanel'
 import ImageItem, { ImageData } from './ImageItem'
@@ -403,6 +404,8 @@ export default function InteractiveCanvas() {
             <span className="relative">🎵</span>
           </button>
         </div>
+
+        <SideNotes />
 
         {audioVisible && (
           <MusicPanel

--- a/components/chat/ChatBox.tsx
+++ b/components/chat/ChatBox.tsx
@@ -57,9 +57,9 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author, collapsed = false, on
         <button
           onClick={() => onToggle?.()}
           aria-label="Expand chat panel"
-          className="absolute top-1/2 -translate-y-1/2 -left-6 p-2 rounded-full border border-white/10 bg-black/20 text-white"
+          className="absolute top-1/2 -translate-y-1/2 -left-4 w-8 h-8 flex items-center justify-center rounded-full border border-white/10 bg-black/20 text-white"
         >
-          <ChevronLeft />
+          <ChevronLeft className="w-7 h-7" strokeWidth={3} />
         </button>
       </aside>
     )
@@ -87,9 +87,9 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author, collapsed = false, on
         <button
           onClick={() => onToggle?.()}
           aria-label="Collapse chat panel"
-          className="absolute top-1/2 -translate-y-1/2 -left-6 p-2 rounded-full border border-white/10 bg-black/20 text-white"
+          className="absolute top-1/2 -translate-y-1/2 -left-4 w-8 h-8 flex items-center justify-center rounded-full border border-white/10 bg-black/20 text-white"
         >
-          <ChevronRight />
+          <ChevronRight className="w-7 h-7" strokeWidth={3} />
         </button>
         <SessionSummary onClose={() => setShowSummary(false)} />
       </aside>
@@ -116,9 +116,9 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author, collapsed = false, on
       <button
         onClick={() => onToggle?.()}
         aria-label="Collapse chat panel"
-        className="absolute top-1/2 -translate-y-1/2 -left-6 p-2 rounded-full border border-white/10 bg-black/20 text-white"
+        className="absolute top-1/2 -translate-y-1/2 -left-4 w-8 h-8 flex items-center justify-center rounded-full border border-white/10 bg-black/20 text-white"
       >
-        <ChevronRight />
+        <ChevronRight className="w-7 h-7" strokeWidth={3} />
       </button>
       {/* Boutons en-tête */}
       <div className="flex justify-center items-center mb-2 gap-2">

--- a/components/chat/ChatBox.tsx
+++ b/components/chat/ChatBox.tsx
@@ -53,8 +53,12 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author, collapsed = false, on
 
   if (collapsed) {
     return (
-      <aside className="w-12 p-2 flex items-center justify-center bg-black/15 border border-white/10 rounded-xl backdrop-blur-[2px] shadow-lg shadow-black/10 transition-all duration-300">
-        <button onClick={() => onToggle?.()} aria-label="Expand chat panel" className="text-white">
+      <aside className="relative w-0 h-full">
+        <button
+          onClick={() => onToggle?.()}
+          aria-label="Expand chat panel"
+          className="absolute top-1/2 -translate-y-1/2 -left-6 p-2 rounded-full border border-white/10 bg-black/20 text-white"
+        >
           <ChevronLeft />
         </button>
       </aside>
@@ -83,7 +87,7 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author, collapsed = false, on
         <button
           onClick={() => onToggle?.()}
           aria-label="Collapse chat panel"
-          className="absolute top-2 left-2 text-white"
+          className="absolute top-1/2 -translate-y-1/2 -left-6 p-2 rounded-full border border-white/10 bg-black/20 text-white"
         >
           <ChevronRight />
         </button>
@@ -112,7 +116,7 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author, collapsed = false, on
       <button
         onClick={() => onToggle?.()}
         aria-label="Collapse chat panel"
-        className="absolute top-2 left-2 text-white"
+        className="absolute top-1/2 -translate-y-1/2 -left-6 p-2 rounded-full border border-white/10 bg-black/20 text-white"
       >
         <ChevronRight />
       </button>

--- a/components/chat/ChatBox.tsx
+++ b/components/chat/ChatBox.tsx
@@ -63,7 +63,7 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author, collapsed = false, on
             transition={{ duration: 0.3 }}
             onClick={() => onToggle?.()}
             aria-label="Expand chat panel"
-            className="absolute top-1/2 -translate-y-1/2 -left-4 text-white"
+            className="absolute top-1/2 -translate-y-1/2 -left-4 text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
           >
             <ChevronLeft className="w-7 h-7" strokeWidth={3} />
           </motion.button>
@@ -75,7 +75,7 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author, collapsed = false, on
             exit={{ x: 420 }}
             transition={{ duration: 0.3 }}
             className="
-              w-full lg:w-1/5
+              w-full md:w-[420px] flex-none
               p-4 flex flex-col relative
               rounded-xl border border-white/10
               bg-black/15 backdrop-blur-[2px]
@@ -86,7 +86,7 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author, collapsed = false, on
             <button
               onClick={() => onToggle?.()}
               aria-label="Collapse chat panel"
-              className="absolute top-1/2 -translate-y-1/2 left-2 text-white"
+              className="absolute top-1/2 -translate-y-1/2 -left-4 text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
             >
               <ChevronRight className="w-7 h-7" strokeWidth={3} />
             </button>
@@ -100,7 +100,7 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author, collapsed = false, on
             exit={{ x: 420 }}
             transition={{ duration: 0.3 }}
             className="
-              w-full lg:w-1/5
+              w-full md:w-[420px] flex-none
               p-4 flex flex-col relative h-full min-h-0
               rounded-xl border border-white/10
               bg-black/15 backdrop-blur-[2px]
@@ -111,7 +111,7 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author, collapsed = false, on
             <button
               onClick={() => onToggle?.()}
               aria-label="Collapse chat panel"
-              className="absolute top-1/2 -translate-y-1/2 left-2 text-white"
+              className="absolute top-1/2 -translate-y-1/2 -left-4 text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
             >
               <ChevronRight className="w-7 h-7" strokeWidth={3} />
             </button>

--- a/components/chat/ChatBox.tsx
+++ b/components/chat/ChatBox.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { FC, RefObject, useRef, useState, useEffect } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useBroadcastEvent, useRoom } from '@liveblocks/react'
 import useProfile from '../app/hooks/useProfile'
 import SessionSummary from './SessionSummary'
@@ -13,9 +14,11 @@ interface Props {
   chatBoxRef: RefObject<HTMLDivElement | null>
   history: Roll[]
   author: string
+  collapsed?: boolean
+  onToggle?: () => void
 }
 
-const ChatBox: FC<Props> = ({ chatBoxRef, history, author }) => {
+const ChatBox: FC<Props> = ({ chatBoxRef, history, author, collapsed = false, onToggle }) => {
   const room = useRoom()
   const { events, addEvent } = useEventLog(room.id)
   const sortedEvents = [...events].sort((a, b) => a.ts - b.ts)
@@ -48,6 +51,16 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author }) => {
     endRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [events])
 
+  if (collapsed) {
+    return (
+      <aside className="w-12 p-2 flex items-center justify-center bg-black/15 border border-white/10 rounded-xl backdrop-blur-[2px] shadow-lg shadow-black/10 transition-all duration-300">
+        <button onClick={() => onToggle?.()} aria-label="Expand chat panel" className="text-white">
+          <ChevronLeft />
+        </button>
+      </aside>
+    )
+  }
+
   // --- NOUVEL AFFICHAGE VERTICAL ---
   if (showSummary) {
     return (
@@ -67,6 +80,13 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author }) => {
           boxShadow: '0 4px 18px -8px rgba(0,0,0,0.24), 0 0 0 1px rgba(255,255,255,0.05)'
         }}
       >
+        <button
+          onClick={() => onToggle?.()}
+          aria-label="Collapse chat panel"
+          className="absolute top-2 left-2 text-white"
+        >
+          <ChevronRight />
+        </button>
         <SessionSummary onClose={() => setShowSummary(false)} />
       </aside>
     )
@@ -89,6 +109,13 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author }) => {
         boxShadow: '0 4px 18px -8px rgba(0,0,0,0.24), 0 0 0 1px rgba(255,255,255,0.05)'
       }}
     >
+      <button
+        onClick={() => onToggle?.()}
+        aria-label="Collapse chat panel"
+        className="absolute top-2 left-2 text-white"
+      >
+        <ChevronRight />
+      </button>
       {/* Boutons en-tête */}
       <div className="flex justify-center items-center mb-2 gap-2">
         <button

--- a/components/chat/ChatBox.tsx
+++ b/components/chat/ChatBox.tsx
@@ -55,27 +55,31 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author, collapsed = false, on
     <div className="relative h-full">
       <AnimatePresence initial={false}>
         {collapsed ? (
-          <motion.button
-            key="open"
-            initial={{ x: 40, opacity: 0 }}
+          <motion.aside
+            key="collapsed"
+            initial={{ x: 0, opacity: 0 }}
             animate={{ x: 0, opacity: 1 }}
-            exit={{ x: 40, opacity: 0 }}
+            exit={{ x: 0, opacity: 0 }}
             transition={{ duration: 0.3 }}
-            onClick={() => onToggle?.()}
-            aria-label="Expand chat panel"
-            className="absolute top-1/2 -translate-y-1/2 -left-4 text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
+            className="w-12 flex-none flex items-start justify-center pt-2"
           >
-            <ChevronLeft className="w-7 h-7" strokeWidth={3} />
-          </motion.button>
+            <button
+              onClick={() => onToggle?.()}
+              aria-label="Expand chat panel"
+              className="text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
+            >
+              <ChevronLeft className="w-7 h-7" strokeWidth={3} />
+            </button>
+          </motion.aside>
         ) : showSummary ? (
           <motion.aside
             key="summary"
-            initial={{ x: 420 }}
+            initial={{ x: '100%' }}
             animate={{ x: 0 }}
-            exit={{ x: 420 }}
+            exit={{ x: '100%' }}
             transition={{ duration: 0.3 }}
             className="
-              w-full md:w-[420px] flex-none
+              w-full lg:w-1/5 flex-none
               p-4 flex flex-col relative
               rounded-xl border border-white/10
               bg-black/15 backdrop-blur-[2px]
@@ -86,7 +90,7 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author, collapsed = false, on
             <button
               onClick={() => onToggle?.()}
               aria-label="Collapse chat panel"
-              className="absolute top-1/2 -translate-y-1/2 -left-4 text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
+              className="absolute top-2 left-2 text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
             >
               <ChevronRight className="w-7 h-7" strokeWidth={3} />
             </button>
@@ -95,12 +99,12 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author, collapsed = false, on
         ) : (
           <motion.aside
             key="panel"
-            initial={{ x: 420 }}
+            initial={{ x: '100%' }}
             animate={{ x: 0 }}
-            exit={{ x: 420 }}
+            exit={{ x: '100%' }}
             transition={{ duration: 0.3 }}
             className="
-              w-full md:w-[420px] flex-none
+              w-full lg:w-1/5 flex-none
               p-4 flex flex-col relative h-full min-h-0
               rounded-xl border border-white/10
               bg-black/15 backdrop-blur-[2px]
@@ -111,7 +115,7 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author, collapsed = false, on
             <button
               onClick={() => onToggle?.()}
               aria-label="Collapse chat panel"
-              className="absolute top-1/2 -translate-y-1/2 -left-4 text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
+              className="absolute top-2 left-2 text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
             >
               <ChevronRight className="w-7 h-7" strokeWidth={3} />
             </button>

--- a/components/chat/ChatBox.tsx
+++ b/components/chat/ChatBox.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { FC, RefObject, useRef, useState, useEffect } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { motion, AnimatePresence } from 'framer-motion'
 import { useBroadcastEvent, useRoom } from '@liveblocks/react'
 import useProfile from '../app/hooks/useProfile'
 import SessionSummary from './SessionSummary'
@@ -50,219 +51,213 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author, collapsed = false, on
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [events])
-
-  if (collapsed) {
-    return (
-      <aside className="relative w-0 h-full">
-        <button
-          onClick={() => onToggle?.()}
-          aria-label="Expand chat panel"
-          className="absolute top-1/2 -translate-y-1/2 -left-4 w-8 h-8 flex items-center justify-center rounded-full border border-white/10 bg-black/20 text-white"
-        >
-          <ChevronLeft className="w-7 h-7" strokeWidth={3} />
-        </button>
-      </aside>
-    )
-  }
-
-  // --- NOUVEL AFFICHAGE VERTICAL ---
-  if (showSummary) {
-    return (
-      <aside
-        className="
-          w-full lg:w-1/5
-          p-4
-          flex flex-col relative
-          rounded-xl
-          border border-white/10
-          bg-black/15
-          backdrop-blur-[2px]
-          shadow-lg shadow-black/10
-          transition
-        "
-        style={{
-          boxShadow: '0 4px 18px -8px rgba(0,0,0,0.24), 0 0 0 1px rgba(255,255,255,0.05)'
-        }}
-      >
-        <button
-          onClick={() => onToggle?.()}
-          aria-label="Collapse chat panel"
-          className="absolute top-1/2 -translate-y-1/2 -left-4 w-8 h-8 flex items-center justify-center rounded-full border border-white/10 bg-black/20 text-white"
-        >
-          <ChevronRight className="w-7 h-7" strokeWidth={3} />
-        </button>
-        <SessionSummary onClose={() => setShowSummary(false)} />
-      </aside>
-    )
-  }
-
   return (
-    <aside
-      className="
-        w-full lg:w-1/5
-        p-4
-        flex flex-col relative h-full min-h-0
-        rounded-xl
-        border border-white/10
-        bg-black/15
-        backdrop-blur-[2px]
-        shadow-lg shadow-black/10
-        transition
-      "
-      style={{
-        boxShadow: '0 4px 18px -8px rgba(0,0,0,0.24), 0 0 0 1px rgba(255,255,255,0.05)'
-      }}
-    >
-      <button
-        onClick={() => onToggle?.()}
-        aria-label="Collapse chat panel"
-        className="absolute top-1/2 -translate-y-1/2 -left-4 w-8 h-8 flex items-center justify-center rounded-full border border-white/10 bg-black/20 text-white"
-      >
-        <ChevronRight className="w-7 h-7" strokeWidth={3} />
-      </button>
-      {/* Boutons en-tête */}
-      <div className="flex justify-center items-center mb-2 gap-2">
-        <button
-          className="
-            px-5 py-2 rounded-xl font-semibold shadow border-none
-            bg-black/30 text-white/90
-            hover:bg-yellow-400 hover:text-black
-            transition
-            duration-100
-            flex items-center justify-center
-            min-h-[44px]
-          "
-          style={{ minHeight: 44 }}
-        onClick={() => setShowSummary(true)}
-      >
-          {t('sessionSummary')}
-        </button>
-        <button
-          className="
-            px-5 py-2 rounded-xl font-semibold shadow border-none
-            bg-black/30 text-white/90
-            hover:bg-blue-600 hover:text-white
-            transition
-            duration-100
-            flex items-center justify-center
-            min-h-[44px]
-          "
-          style={{ minHeight: 44 }}
-          onClick={() => setShowStats(s => !s)}
-          title={t('diceStats')}
-        >
-          {showStats ? t('chat') : '📊'}
-        </button>
-      </div>
-
-      {/* --- Affichage vertical : stats en haut, chat en bas --- */}
-      <div className="flex flex-col flex-1 min-h-0 gap-2">
-        {showStats && (
-          <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-            <div className="text-center font-bold mb-2">{t('diceStatsTitle')}</div>
-            <div className="
-              flex-1 overflow-y-auto
-              rounded-xl
-              border border-white/10
-              bg-black/15
-              backdrop-blur-[2px]
-              shadow
-              p-2
-              min-h-0
-            ">
-              <DiceStats history={history} />
-            </div>
-          </div>
-        )}
-        <div className={`flex-1 min-h-0 flex flex-col ${showStats ? '' : 'h-full'}`}>
-          <h2 className="text-xl font-bold mb-2 text-center">{t('chat')}</h2>
-          <div
-            ref={chatBoxRef}
+    <div className="relative h-full">
+      <AnimatePresence initial={false}>
+        {collapsed ? (
+          <motion.button
+            key="open"
+            initial={{ x: 40, opacity: 0 }}
+            animate={{ x: 0, opacity: 1 }}
+            exit={{ x: 40, opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            onClick={() => onToggle?.()}
+            aria-label="Expand chat panel"
+            className="absolute top-1/2 -translate-y-1/2 -left-4 text-white"
+          >
+            <ChevronLeft className="w-7 h-7" strokeWidth={3} />
+          </motion.button>
+        ) : showSummary ? (
+          <motion.aside
+            key="summary"
+            initial={{ x: 420 }}
+            animate={{ x: 0 }}
+            exit={{ x: 420 }}
+            transition={{ duration: 0.3 }}
             className="
-              relative
-              flex-1 overflow-y-auto
-              rounded-xl
-              border border-white/10
-              bg-black/15
-              backdrop-blur-[2px]
-              shadow
-              p-2
-              min-h-0
+              w-full lg:w-1/5
+              p-4 flex flex-col relative
+              rounded-xl border border-white/10
+              bg-black/15 backdrop-blur-[2px]
+              shadow-lg shadow-black/10
             "
+            style={{ boxShadow: '0 4px 18px -8px rgba(0,0,0,0.24), 0 0 0 1px rgba(255,255,255,0.05)' }}
           >
             <button
-              onClick={() => setShowHistory(h => !h)}
-              className="absolute left-1/2 -translate-x-1/2 top-1 text-xs opacity-20 hover:opacity-80 bg-black/20 px-2 py-1 rounded"
-              title={showHistory ? t('hideHistory') : t('showHistory')}
+              onClick={() => onToggle?.()}
+              aria-label="Collapse chat panel"
+              className="absolute top-1/2 -translate-y-1/2 left-2 text-white"
             >
-              🕘
+              <ChevronRight className="w-7 h-7" strokeWidth={3} />
             </button>
-            {displayedEvents.map(ev => (
-              <p key={ev.id}>
-                <span className="mr-1">{ev.kind === 'chat' ? '💬' : '🎲'}</span>
-                {ev.kind === 'chat' && (
-                  <><strong>{ev.author}{ev.isMJ && ' 👑'} :</strong> {ev.text}</>
-                )}
-                {ev.kind === 'dice' && (
-                  <span>{ev.player} : D{ev.dice} → {ev.result}</span>
-                )}
-              </p>
-            ))}
-            <div ref={endRef} />
-          </div>
-            <div className="mt-2 flex items-center w-full max-w-full overflow-hidden">
-            <input
-              type="text"
-              placeholder={t('yourMessage')}
-              value={inputValue}
-              onChange={e => setInputValue(e.target.value)}
-              onKeyDown={e => {
-              if (e.key === 'Enter') sendMessage()
-              }}
-              className="
-              flex-1
-              border-none
-              px-3 py-2
-              rounded-l-xl
-              text-white
-              bg-black/30
-              backdrop-blur-[2px]
-              focus:outline-none
-              transition
-              shadow
-              placeholder:text-white/50
-              text-base
-              min-w-0
-              "
-              style={{ minHeight: 44 }}
-            />
+            <SessionSummary onClose={() => setShowSummary(false)} />
+          </motion.aside>
+        ) : (
+          <motion.aside
+            key="panel"
+            initial={{ x: 420 }}
+            animate={{ x: 0 }}
+            exit={{ x: 420 }}
+            transition={{ duration: 0.3 }}
+            className="
+              w-full lg:w-1/5
+              p-4 flex flex-col relative h-full min-h-0
+              rounded-xl border border-white/10
+              bg-black/15 backdrop-blur-[2px]
+              shadow-lg shadow-black/10
+            "
+            style={{ boxShadow: '0 4px 18px -8px rgba(0,0,0,0.24), 0 0 0 1px rgba(255,255,255,0.05)' }}
+          >
             <button
-              onClick={sendMessage}
-              className="
-              rounded-r-xl
-              px-5 py-2
-              text-base
-              font-semibold
-              shadow
-              border-none
-              bg-black/30
-              text-white/90
-              hover:bg-emerald-600 hover:text-white
-              transition
-              duration-100
-              flex items-center justify-center
-              min-h-[44px]
-              max-w-[120px]
-              truncate
-              "
-              style={{ minHeight: 44 }}
+              onClick={() => onToggle?.()}
+              aria-label="Collapse chat panel"
+              className="absolute top-1/2 -translate-y-1/2 left-2 text-white"
             >
-              {t('send')}
+              <ChevronRight className="w-7 h-7" strokeWidth={3} />
             </button>
+            <div className="flex justify-center items-center mb-2 gap-2">
+              <button
+                className="
+                  px-5 py-2 rounded-xl font-semibold shadow border-none
+                  bg-black/30 text-white/90
+                  hover:bg-yellow-400 hover:text-black
+                  transition
+                  duration-100
+                  flex items-center justify-center
+                  min-h-[44px]
+                "
+                style={{ minHeight: 44 }}
+                onClick={() => setShowSummary(true)}
+              >
+                {t('sessionSummary')}
+              </button>
+              <button
+                className="
+                  px-5 py-2 rounded-xl font-semibold shadow border-none
+                  bg-black/30 text-white/90
+                  hover:bg-blue-600 hover:text-white
+                  transition
+                  duration-100
+                  flex items-center justify-center
+                  min-h-[44px]
+                "
+                style={{ minHeight: 44 }}
+                onClick={() => setShowStats(s => !s)}
+                title={t('diceStats')}
+              >
+                {showStats ? t('chat') : '📊'}
+              </button>
             </div>
-        </div>
-      </div>
-    </aside>
+            <div className="flex flex-col flex-1 min-h-0 gap-2">
+              {showStats && (
+                <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+                  <div className="text-center font-bold mb-2">{t('diceStatsTitle')}</div>
+                  <div className="
+                    flex-1 overflow-y-auto
+                    rounded-xl
+                    border border-white/10
+                    bg-black/15
+                    backdrop-blur-[2px]
+                    shadow
+                    p-2
+                    min-h-0
+                  ">
+                    <DiceStats history={history} />
+                  </div>
+                </div>
+              )}
+              <div className={`flex-1 min-h-0 flex flex-col ${showStats ? '' : 'h-full'}`}>
+                <h2 className="text-xl font-bold mb-2 text-center">{t('chat')}</h2>
+                <div
+                  ref={chatBoxRef}
+                  className="
+                    relative
+                    flex-1 overflow-y-auto
+                    rounded-xl
+                    border border-white/10
+                    bg-black/15
+                    backdrop-blur-[2px]
+                    shadow
+                    p-2
+                    min-h-0
+                  "
+                >
+                  <button
+                    onClick={() => setShowHistory(h => !h)}
+                    className="absolute left-1/2 -translate-x-1/2 top-1 text-xs opacity-20 hover:opacity-80 bg-black/20 px-2 py-1 rounded"
+                    title={showHistory ? t('hideHistory') : t('showHistory')}
+                  >
+                    🕘
+                  </button>
+                  {displayedEvents.map(ev => (
+                    <p key={ev.id}>
+                      <span className="mr-1">{ev.kind === 'chat' ? '💬' : '🎲'}</span>
+                      {ev.kind === 'chat' && (
+                        <><strong>{ev.author}{ev.isMJ && ' 👑'} :</strong> {ev.text}</>
+                      )}
+                      {ev.kind === 'dice' && (
+                        <span>{ev.player} : D{ev.dice} → {ev.result}</span>
+                      )}
+                    </p>
+                  ))}
+                  <div ref={endRef} />
+                </div>
+                <div className="mt-2 flex items-center w-full max-w-full overflow-hidden">
+                  <input
+                    type="text"
+                    placeholder={t('yourMessage')}
+                    value={inputValue}
+                    onChange={e => setInputValue(e.target.value)}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter') sendMessage()
+                    }}
+                    className="
+                      flex-1
+                      border-none
+                      px-3 py-2
+                      rounded-l-xl
+                      text-white
+                      bg-black/30
+                      backdrop-blur-[2px]
+                      focus:outline-none
+                      transition
+                      shadow
+                      placeholder:text-white/50
+                      text-base
+                      min-w-0
+                    "
+                    style={{ minHeight: 44 }}
+                  />
+                  <button
+                    onClick={sendMessage}
+                    className="
+                      rounded-r-xl
+                      px-5 py-2
+                      text-base
+                      font-semibold
+                      shadow
+                      border-none
+                      bg-black/30
+                      text-white/90
+                      hover:bg-emerald-600 hover:text-white
+                      transition
+                      duration-100
+                      flex items-center justify-center
+                      min-h-[44px]
+                      max-w-[120px]
+                      truncate
+                    "
+                    style={{ minHeight: 44 }}
+                  >
+                    {t('send')}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </motion.aside>
+        )}
+      </AnimatePresence>
+    </div>
   )
 }
 

--- a/components/dice/DiceRoller.tsx
+++ b/components/dice/DiceRoller.tsx
@@ -89,9 +89,9 @@ const DiceRoller: FC<Props> = ({
         <button
           onClick={() => onToggle?.()}
           aria-label="Expand dice panel"
-          className="absolute left-1/2 -translate-x-1/2 -top-6 p-2 rounded-full border border-white/10 bg-black/20 text-white"
+          className="absolute left-1/2 -translate-x-1/2 -top-4 w-8 h-8 flex items-center justify-center rounded-full border border-white/10 bg-black/20 text-white"
         >
-          <ChevronUp />
+          <ChevronUp className="w-7 h-7" strokeWidth={3} />
         </button>
       </div>
     )
@@ -116,9 +116,9 @@ const DiceRoller: FC<Props> = ({
       <button
         onClick={() => onToggle?.()}
         aria-label="Collapse dice panel"
-        className="absolute left-1/2 -translate-x-1/2 -top-6 p-2 rounded-full border border-white/10 bg-black/20 text-white"
+        className="absolute left-1/2 -translate-x-1/2 -top-4 w-8 h-8 flex items-center justify-center rounded-full border border-white/10 bg-black/20 text-white"
       >
-        <ChevronDown />
+        <ChevronDown className="w-7 h-7" strokeWidth={3} />
       </button>
       <label htmlFor="diceType" className="mr-2 font-semibold text-white/85">
         {t('diceType')}:

--- a/components/dice/DiceRoller.tsx
+++ b/components/dice/DiceRoller.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { FC, useRef } from 'react'
-import { Dice3 } from 'lucide-react'
+import { Dice3, ChevronDown, ChevronUp } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { useT } from '@/lib/useT'
 
@@ -13,6 +13,8 @@ type Props = {
   cooldown: boolean
   cooldownDuration: number
   children?: React.ReactNode
+  collapsed?: boolean
+  onToggle?: () => void
 }
 
 const DiceRoller: FC<Props> = ({
@@ -22,7 +24,9 @@ const DiceRoller: FC<Props> = ({
   disabled,
   cooldown,
   cooldownDuration,
-  children
+  children,
+  collapsed = false,
+  onToggle
 }) => {
   const t = useT()
   const clickLockRef = useRef(false)
@@ -79,6 +83,18 @@ const DiceRoller: FC<Props> = ({
     }
   }
 
+  if (collapsed) {
+    return (
+      <div
+        className="h-12 p-2 flex items-center justify-center rounded-xl border border-white/10 bg-black/15 backdrop-blur-[2px] shadow-lg shadow-black/10 transition-all duration-300"
+      >
+        <button onClick={() => onToggle?.()} aria-label="Expand dice panel" className="text-white">
+          <ChevronUp />
+        </button>
+      </div>
+    )
+  }
+
   return (
     <div
       className="
@@ -89,12 +105,19 @@ const DiceRoller: FC<Props> = ({
         bg-black/15
         backdrop-blur-[2px]
         shadow-lg shadow-black/10
-        transition
+        transition relative
       "
       style={{
         boxShadow: '0 4px 18px -8px rgba(0,0,0,0.24), 0 0 0 1px rgba(255,255,255,0.05)',
       }}
     >
+      <button
+        onClick={() => onToggle?.()}
+        aria-label="Collapse dice panel"
+        className="absolute top-2 right-2 text-white"
+      >
+        <ChevronDown />
+      </button>
       <label htmlFor="diceType" className="mr-2 font-semibold text-white/85">
         {t('diceType')}:
       </label>

--- a/components/dice/DiceRoller.tsx
+++ b/components/dice/DiceRoller.tsx
@@ -2,7 +2,7 @@
 
 import { FC, useRef } from 'react'
 import { Dice3, ChevronDown, ChevronUp } from 'lucide-react'
-import { motion } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 import { useT } from '@/lib/useT'
 
 type Props = {
@@ -83,43 +83,50 @@ const DiceRoller: FC<Props> = ({
     }
   }
 
-  if (collapsed) {
-    return (
-      <div className="relative w-full h-0">
-        <button
-          onClick={() => onToggle?.()}
-          aria-label="Expand dice panel"
-          className="absolute left-1/2 -translate-x-1/2 -top-4 w-8 h-8 flex items-center justify-center rounded-full border border-white/10 bg-black/20 text-white"
-        >
-          <ChevronUp className="w-7 h-7" strokeWidth={3} />
-        </button>
-      </div>
-    )
-  }
-
   return (
-    <div
-      className="
-        p-4
-        flex items-center gap-2 justify-between
-        rounded-xl
-        border border-white/10
-        bg-black/15
-        backdrop-blur-[2px]
-        shadow-lg shadow-black/10
-        transition relative
-      "
-      style={{
-        boxShadow: '0 4px 18px -8px rgba(0,0,0,0.24), 0 0 0 1px rgba(255,255,255,0.05)',
-      }}
-    >
-      <button
-        onClick={() => onToggle?.()}
-        aria-label="Collapse dice panel"
-        className="absolute left-1/2 -translate-x-1/2 -top-4 w-8 h-8 flex items-center justify-center rounded-full border border-white/10 bg-black/20 text-white"
-      >
-        <ChevronDown className="w-7 h-7" strokeWidth={3} />
-      </button>
+    <div className="relative w-full">
+      <AnimatePresence initial={false}>
+        {collapsed ? (
+          <motion.button
+            key="open"
+            initial={{ y: 40, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            exit={{ y: 40, opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            onClick={() => onToggle?.()}
+            aria-label="Expand dice panel"
+            className="absolute left-1/2 -translate-x-1/2 -top-4 text-white"
+          >
+            <ChevronUp className="w-7 h-7" strokeWidth={3} />
+          </motion.button>
+        ) : (
+          <motion.div
+            key="panel"
+            initial={{ y: 100 }}
+            animate={{ y: 0 }}
+            exit={{ y: 100 }}
+            transition={{ duration: 0.3 }}
+            className="
+              p-4
+              flex items-center gap-2 justify-between
+              rounded-xl
+              border border-white/10
+              bg-black/15
+              backdrop-blur-[2px]
+              shadow-lg shadow-black/10
+              relative
+            "
+            style={{
+              boxShadow: '0 4px 18px -8px rgba(0,0,0,0.24), 0 0 0 1px rgba(255,255,255,0.05)',
+            }}
+          >
+            <button
+              onClick={() => onToggle?.()}
+              aria-label="Collapse dice panel"
+              className="absolute left-1/2 -translate-x-1/2 top-2 text-white"
+            >
+              <ChevronDown className="w-7 h-7" strokeWidth={3} />
+            </button>
       <label htmlFor="diceType" className="mr-2 font-semibold text-white/85">
         {t('diceType')}:
       </label>
@@ -173,6 +180,9 @@ const DiceRoller: FC<Props> = ({
       </div>
 
       {children && <div className="ml-auto flex gap-1">{children}</div>}
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   )
 }

--- a/components/dice/DiceRoller.tsx
+++ b/components/dice/DiceRoller.tsx
@@ -95,7 +95,7 @@ const DiceRoller: FC<Props> = ({
             transition={{ duration: 0.3 }}
             onClick={() => onToggle?.()}
             aria-label="Expand dice panel"
-            className="absolute left-1/2 -translate-x-1/2 -top-4 text-white"
+            className="absolute left-1/2 -translate-x-1/2 -top-4 text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
           >
             <ChevronUp className="w-7 h-7" strokeWidth={3} />
           </motion.button>
@@ -107,7 +107,7 @@ const DiceRoller: FC<Props> = ({
             exit={{ y: 100 }}
             transition={{ duration: 0.3 }}
             className="
-              p-4
+              p-4 flex-none
               flex items-center gap-2 justify-between
               rounded-xl
               border border-white/10
@@ -123,7 +123,7 @@ const DiceRoller: FC<Props> = ({
             <button
               onClick={() => onToggle?.()}
               aria-label="Collapse dice panel"
-              className="absolute left-1/2 -translate-x-1/2 top-2 text-white"
+              className="absolute left-1/2 -translate-x-1/2 -top-4 text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
             >
               <ChevronDown className="w-7 h-7" strokeWidth={3} />
             </button>

--- a/components/dice/DiceRoller.tsx
+++ b/components/dice/DiceRoller.tsx
@@ -85,10 +85,12 @@ const DiceRoller: FC<Props> = ({
 
   if (collapsed) {
     return (
-      <div
-        className="h-12 p-2 flex items-center justify-center rounded-xl border border-white/10 bg-black/15 backdrop-blur-[2px] shadow-lg shadow-black/10 transition-all duration-300"
-      >
-        <button onClick={() => onToggle?.()} aria-label="Expand dice panel" className="text-white">
+      <div className="relative w-full h-0">
+        <button
+          onClick={() => onToggle?.()}
+          aria-label="Expand dice panel"
+          className="absolute left-1/2 -translate-x-1/2 -top-6 p-2 rounded-full border border-white/10 bg-black/20 text-white"
+        >
           <ChevronUp />
         </button>
       </div>
@@ -114,7 +116,7 @@ const DiceRoller: FC<Props> = ({
       <button
         onClick={() => onToggle?.()}
         aria-label="Collapse dice panel"
-        className="absolute top-2 right-2 text-white"
+        className="absolute left-1/2 -translate-x-1/2 -top-6 p-2 rounded-full border border-white/10 bg-black/20 text-white"
       >
         <ChevronDown />
       </button>

--- a/components/dice/DiceRoller.tsx
+++ b/components/dice/DiceRoller.tsx
@@ -87,24 +87,28 @@ const DiceRoller: FC<Props> = ({
     <div className="relative w-full">
       <AnimatePresence initial={false}>
         {collapsed ? (
-          <motion.button
-            key="open"
-            initial={{ y: 40, opacity: 0 }}
+          <motion.div
+            key="collapsed"
+            initial={{ y: 0, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
-            exit={{ y: 40, opacity: 0 }}
+            exit={{ y: 0, opacity: 0 }}
             transition={{ duration: 0.3 }}
-            onClick={() => onToggle?.()}
-            aria-label="Expand dice panel"
-            className="absolute left-1/2 -translate-x-1/2 -top-4 text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
+            className="h-12 flex items-center justify-center"
           >
-            <ChevronUp className="w-7 h-7" strokeWidth={3} />
-          </motion.button>
+            <button
+              onClick={() => onToggle?.()}
+              aria-label="Expand dice panel"
+              className="text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
+            >
+              <ChevronUp className="w-7 h-7" strokeWidth={3} />
+            </button>
+          </motion.div>
         ) : (
           <motion.div
             key="panel"
-            initial={{ y: 100 }}
+            initial={{ y: '100%' }}
             animate={{ y: 0 }}
-            exit={{ y: 100 }}
+            exit={{ y: '100%' }}
             transition={{ duration: 0.3 }}
             className="
               p-4 flex-none

--- a/components/misc/SideNotes.tsx
+++ b/components/misc/SideNotes.tsx
@@ -8,11 +8,10 @@ const HEIGHT_KEY = 'jdr_side_notes_height'
 export default function SideNotes() {
   const [open, setOpen] = useState(false)
   const [notes, setNotes] = useState('')
-  const [height, setHeight] = useState<number>(192) // 48*4 = 192px par défaut
+  const [height, setHeight] = useState<number>(192)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const t = useT()
 
-  // Charger les notes et la hauteur au démarrage
   useEffect(() => {
     const saved = localStorage.getItem(STORAGE_KEY)
     if (saved) setNotes(saved)
@@ -20,17 +19,14 @@ export default function SideNotes() {
     if (savedHeight) setHeight(Number(savedHeight))
   }, [])
 
-  // Sauver les notes à chaque modif
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, notes)
   }, [notes])
 
-  // Sauver la hauteur à chaque modif
   useEffect(() => {
     localStorage.setItem(HEIGHT_KEY, String(height))
   }, [height])
 
-  // Gérer la détection de resize (on le fait à la fermeture OU quand on perd le focus)
   const handleResize = () => {
     if (textareaRef.current) {
       setHeight(textareaRef.current.offsetHeight)
@@ -38,18 +34,9 @@ export default function SideNotes() {
   }
 
   return (
-    <div
-      className="fixed top-1/2 -translate-y-1/2 z-50"
-      style={{ left: 430 }}
-    >
+    <div className="absolute left-3 bottom-3 z-30">
       {open ? (
-        <div
-          className="
-            relative rounded-2xl border border-white/10
-            bg-black/30 backdrop-blur-[2.5px] shadow-2xl shadow-black/15
-            text-white p-3 w-72 transition-all
-          "
-        >
+        <div className="absolute bottom-0 left-0 rounded-2xl border border-white/10 bg-black/30 backdrop-blur-[2.5px] shadow-2xl shadow-black/15 text-white p-3 w-72 transition-all">
           <textarea
             ref={textareaRef}
             className="w-full bg-black/20 rounded-xl p-2 text-sm resize-y border border-white/10 focus:ring-2 focus:ring-blue-500/20 transition"
@@ -63,64 +50,45 @@ export default function SideNotes() {
             <button
               className="bg-emerald-600/90 hover:bg-emerald-500/90 text-white px-3 py-1 rounded-md text-xs shadow transition"
               onClick={() => localStorage.setItem(STORAGE_KEY, notes)}
-            >{t('save')}</button>
+            >
+              {t('save')}
+            </button>
             <button
-              className="
-                absolute -right-4 top-1/2 -translate-y-1/2
-                bg-black/60 hover:bg-black/90 text-white border border-white/15
-                rounded-xl shadow
-                flex items-center justify-center
-                transition
-              "
+              className="absolute -right-4 top-1/2 -translate-y-1/2 bg-black/60 hover:bg-black/90 text-white border border-white/15 rounded-xl shadow flex items-center justify-center transition"
               onClick={() => {
                 handleResize()
                 setOpen(false)
               }}
               title={t('close')}
-              style={{
-                fontSize: '1.1rem',
-                width: 32,
-                height: 32,
-                padding: 0,
-              }}
+              style={{ fontSize: '1.1rem', width: 32, height: 32, padding: 0 }}
             >
-              <span style={{ fontWeight: 700, fontSize: "1.35em", lineHeight: "1" }}>×</span>
+              <span style={{ fontWeight: 700, fontSize: '1.35em', lineHeight: '1' }}>×</span>
             </button>
           </div>
         </div>
       ) : (
         <button
-  className="
-    bg-black/25 hover:bg-black/50 border border-white/10
-    rounded-xl shadow-lg backdrop-blur-[2.5px]
-    flex items-center justify-center transition
-  "
-  onClick={() => setOpen(true)}
-  title={t('notes')}
-  style={{
-    width: 40,
-    height: 40,
-    fontSize: '1.2rem',
-    padding: 0,
-  }}
->
-  {/* Icône note/papier minimaliste, SVG inline */}
-  <svg
-    width="22"
-    height="22"
-    viewBox="0 0 22 22"
-    fill="none"
-    aria-hidden="true"
-    className="opacity-80"
-  >
-    <rect x="4" y="3.5" width="14" height="15" rx="3.5" stroke="white" strokeWidth="1.3" fill="none"/>
-    <line x1="7" y1="7.7" x2="15" y2="7.7" stroke="white" strokeWidth="1.1" strokeLinecap="round"/>
-    <line x1="7" y1="11" x2="15" y2="11" stroke="white" strokeWidth="1.1" strokeLinecap="round"/>
-    <line x1="7" y1="14.3" x2="13" y2="14.3" stroke="white" strokeWidth="1.1" strokeLinecap="round"/>
-  </svg>
-</button>
-
+          className="bg-black/25 hover:bg-black/50 border border-white/10 rounded-xl shadow-lg backdrop-blur-[2.5px] flex items-center justify-center transition"
+          onClick={() => setOpen(true)}
+          title={t('notes')}
+          style={{ width: 40, height: 40, fontSize: '1.2rem', padding: 0 }}
+        >
+          <svg
+            width="22"
+            height="22"
+            viewBox="0 0 22 22"
+            fill="none"
+            aria-hidden="true"
+            className="opacity-80"
+          >
+            <rect x="4" y="3.5" width="14" height="15" rx="3.5" stroke="white" strokeWidth="1.3" fill="none" />
+            <line x1="7" y1="7.7" x2="15" y2="7.7" stroke="white" strokeWidth="1.1" strokeLinecap="round" />
+            <line x1="7" y1="11" x2="15" y2="11" stroke="white" strokeWidth="1.1" strokeLinecap="round" />
+            <line x1="7" y1="14.3" x2="13" y2="14.3" stroke="white" strokeWidth="1.1" strokeLinecap="round" />
+          </svg>
+        </button>
       )}
     </div>
   )
 }
+

--- a/components/sheet/CharacterSheet.tsx
+++ b/components/sheet/CharacterSheet.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { FC, useState, useEffect } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import StatsTab from './StatsTab'
 import EquipTab from './EquipTab'
 import DescriptionPanel from '../character/DescriptionPanel'
@@ -15,7 +16,9 @@ type Props = {
   creation?: boolean,
   children?: React.ReactNode,
   allCharacters?: any[], // facultatif, si tu veux passer la liste complète
-  logoOnly?: boolean
+  logoOnly?: boolean,
+  collapsed?: boolean,
+  onToggle?: () => void
 }
 
 export const defaultPerso = {
@@ -65,7 +68,9 @@ const CharacterSheet: FC<Props> = ({
   creation = false,
   children,
   allCharacters = [],
-  logoOnly = false
+  logoOnly = false,
+  collapsed = false,
+  onToggle
 }) => {
   // NE PAS relier edit à creation sauf à l'init
   const [edit, setEdit] = useState(!!creation)
@@ -170,6 +175,18 @@ const CharacterSheet: FC<Props> = ({
   }
 
 
+  if (collapsed) {
+    return (
+      <aside
+        className="w-12 p-2 bg-black/10 border border-white/10 backdrop-blur-[2px] shadow shadow-black/5 rounded-2xl flex items-center justify-center transition-all duration-300"
+      >
+        <button onClick={onToggle} aria-label="Expand character panel" className="text-white">
+          <ChevronRight />
+        </button>
+      </aside>
+    )
+  }
+
   return (
     <aside
       className="
@@ -177,7 +194,7 @@ const CharacterSheet: FC<Props> = ({
         bg-black/10 border border-white/10 backdrop-blur-[2px]
         shadow shadow-black/5 rounded-2xl p-5
         pt-0 pb-3 px-3 overflow-y-auto text-[15px] text-white
-        relative select-none
+        relative select-none transition-all duration-300
       "
       style={{
         width: creation ? 'auto' : undefined,
@@ -187,6 +204,13 @@ const CharacterSheet: FC<Props> = ({
         overflowX: 'hidden'
       }}
     >
+      <button
+        onClick={onToggle}
+        aria-label="Collapse character panel"
+        className="absolute top-2 right-2 text-white"
+      >
+        <ChevronLeft />
+      </button>
       {!creation && (
         <CharacterSheetHeader
           edit={edit}

--- a/components/sheet/CharacterSheet.tsx
+++ b/components/sheet/CharacterSheet.tsx
@@ -187,7 +187,7 @@ const CharacterSheet: FC<Props> = ({
             transition={{ duration: 0.3 }}
             onClick={onToggle}
             aria-label="Expand character panel"
-            className="absolute top-1/2 -translate-y-1/2 -right-4 text-white"
+            className="absolute top-1/2 -translate-y-1/2 -right-4 text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
           >
             <ChevronRight className="w-7 h-7" strokeWidth={3} />
           </motion.button>
@@ -199,7 +199,7 @@ const CharacterSheet: FC<Props> = ({
             exit={{ x: -420 }}
             transition={{ duration: 0.3 }}
             className="
-              w-full md:w-[420px]
+              w-full md:w-[420px] flex-none
               bg-black/10 border border-white/10 backdrop-blur-[2px]
               shadow shadow-black/5 rounded-2xl p-5
               pt-0 pb-3 px-3 overflow-y-auto text-[15px] text-white
@@ -216,7 +216,7 @@ const CharacterSheet: FC<Props> = ({
             <button
               onClick={onToggle}
               aria-label="Collapse character panel"
-              className="absolute top-1/2 -translate-y-1/2 right-2 text-white"
+              className="absolute top-1/2 -translate-y-1/2 -right-4 text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
             >
               <ChevronLeft className="w-7 h-7" strokeWidth={3} />
             </button>

--- a/components/sheet/CharacterSheet.tsx
+++ b/components/sheet/CharacterSheet.tsx
@@ -3,6 +3,7 @@
 
 import { FC, useState, useEffect } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { motion, AnimatePresence } from 'framer-motion'
 import StatsTab from './StatsTab'
 import EquipTab from './EquipTab'
 import DescriptionPanel from '../character/DescriptionPanel'
@@ -174,45 +175,51 @@ const CharacterSheet: FC<Props> = ({
     onUpdate(localPerso)
   }
 
-
-  if (collapsed) {
-    return (
-      <aside className="relative w-0 h-full">
-        <button
-          onClick={onToggle}
-          aria-label="Expand character panel"
-          className="absolute top-1/2 -translate-y-1/2 -right-4 w-8 h-8 flex items-center justify-center rounded-full border border-white/10 bg-black/20 text-white"
-        >
-          <ChevronRight className="w-7 h-7" strokeWidth={3} />
-        </button>
-      </aside>
-    )
-  }
-
   return (
-    <aside
-      className="
-        w-full md:w-[420px]
-        bg-black/10 border border-white/10 backdrop-blur-[2px]
-        shadow shadow-black/5 rounded-2xl p-5
-        pt-0 pb-3 px-3 overflow-y-auto text-[15px] text-white
-        relative select-none transition-all duration-300
-      "
-      style={{
-        width: creation ? 'auto' : undefined,
-        minWidth: creation ? '600px' : undefined,
-        maxWidth: creation ? '100%' : undefined,
-        boxSizing: 'border-box',
-        overflowX: 'hidden'
-      }}
-    >
-      <button
-        onClick={onToggle}
-        aria-label="Collapse character panel"
-        className="absolute top-1/2 -translate-y-1/2 -right-4 w-8 h-8 flex items-center justify-center rounded-full border border-white/10 bg-black/20 text-white"
-      >
-        <ChevronLeft className="w-7 h-7" strokeWidth={3} />
-      </button>
+    <div className="relative h-full">
+      <AnimatePresence initial={false}>
+        {collapsed ? (
+          <motion.button
+            key="open"
+            initial={{ x: -40, opacity: 0 }}
+            animate={{ x: 0, opacity: 1 }}
+            exit={{ x: -40, opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            onClick={onToggle}
+            aria-label="Expand character panel"
+            className="absolute top-1/2 -translate-y-1/2 -right-4 text-white"
+          >
+            <ChevronRight className="w-7 h-7" strokeWidth={3} />
+          </motion.button>
+        ) : (
+          <motion.aside
+            key="panel"
+            initial={{ x: -420 }}
+            animate={{ x: 0 }}
+            exit={{ x: -420 }}
+            transition={{ duration: 0.3 }}
+            className="
+              w-full md:w-[420px]
+              bg-black/10 border border-white/10 backdrop-blur-[2px]
+              shadow shadow-black/5 rounded-2xl p-5
+              pt-0 pb-3 px-3 overflow-y-auto text-[15px] text-white
+              relative select-none
+            "
+            style={{
+              width: creation ? 'auto' : undefined,
+              minWidth: creation ? '600px' : undefined,
+              maxWidth: creation ? '100%' : undefined,
+              boxSizing: 'border-box',
+              overflowX: 'hidden'
+            }}
+          >
+            <button
+              onClick={onToggle}
+              aria-label="Collapse character panel"
+              className="absolute top-1/2 -translate-y-1/2 right-2 text-white"
+            >
+              <ChevronLeft className="w-7 h-7" strokeWidth={3} />
+            </button>
       {!creation && (
         <CharacterSheetHeader
           edit={edit}
@@ -292,7 +299,10 @@ const CharacterSheet: FC<Props> = ({
           }}
         />
       )}
-    </aside>
+          </motion.aside>
+        )}
+      </AnimatePresence>
+    </div>
   )
 }
 

--- a/components/sheet/CharacterSheet.tsx
+++ b/components/sheet/CharacterSheet.tsx
@@ -181,9 +181,9 @@ const CharacterSheet: FC<Props> = ({
         <button
           onClick={onToggle}
           aria-label="Expand character panel"
-          className="absolute top-1/2 -translate-y-1/2 -right-6 p-2 rounded-full border border-white/10 bg-black/20 text-white"
+          className="absolute top-1/2 -translate-y-1/2 -right-4 w-8 h-8 flex items-center justify-center rounded-full border border-white/10 bg-black/20 text-white"
         >
-          <ChevronRight />
+          <ChevronRight className="w-7 h-7" strokeWidth={3} />
         </button>
       </aside>
     )
@@ -209,9 +209,9 @@ const CharacterSheet: FC<Props> = ({
       <button
         onClick={onToggle}
         aria-label="Collapse character panel"
-        className="absolute top-1/2 -translate-y-1/2 -right-6 p-2 rounded-full border border-white/10 bg-black/20 text-white"
+        className="absolute top-1/2 -translate-y-1/2 -right-4 w-8 h-8 flex items-center justify-center rounded-full border border-white/10 bg-black/20 text-white"
       >
-        <ChevronLeft />
+        <ChevronLeft className="w-7 h-7" strokeWidth={3} />
       </button>
       {!creation && (
         <CharacterSheetHeader

--- a/components/sheet/CharacterSheet.tsx
+++ b/components/sheet/CharacterSheet.tsx
@@ -179,27 +179,31 @@ const CharacterSheet: FC<Props> = ({
     <div className="relative h-full">
       <AnimatePresence initial={false}>
         {collapsed ? (
-          <motion.button
-            key="open"
-            initial={{ x: -40, opacity: 0 }}
+          <motion.aside
+            key="collapsed"
+            initial={{ x: 0, opacity: 0 }}
             animate={{ x: 0, opacity: 1 }}
-            exit={{ x: -40, opacity: 0 }}
+            exit={{ x: 0, opacity: 0 }}
             transition={{ duration: 0.3 }}
-            onClick={onToggle}
-            aria-label="Expand character panel"
-            className="absolute top-1/2 -translate-y-1/2 -right-4 text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
+            className="w-12 flex-none flex items-start justify-center pt-2"
           >
-            <ChevronRight className="w-7 h-7" strokeWidth={3} />
-          </motion.button>
+            <button
+              onClick={onToggle}
+              aria-label="Expand character panel"
+              className="text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
+            >
+              <ChevronRight className="w-7 h-7" strokeWidth={3} />
+            </button>
+          </motion.aside>
         ) : (
           <motion.aside
             key="panel"
-            initial={{ x: -420 }}
+            initial={{ x: '-100%' }}
             animate={{ x: 0 }}
-            exit={{ x: -420 }}
+            exit={{ x: '-100%' }}
             transition={{ duration: 0.3 }}
             className="
-              w-full md:w-[420px] flex-none
+              w-full lg:w-1/5 flex-none
               bg-black/10 border border-white/10 backdrop-blur-[2px]
               shadow shadow-black/5 rounded-2xl p-5
               pt-0 pb-3 px-3 overflow-y-auto text-[15px] text-white
@@ -216,7 +220,7 @@ const CharacterSheet: FC<Props> = ({
             <button
               onClick={onToggle}
               aria-label="Collapse character panel"
-              className="absolute top-1/2 -translate-y-1/2 -right-4 text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
+              className="absolute top-2 right-2 text-white rounded-full bg-black/30 backdrop-blur-sm p-1"
             >
               <ChevronLeft className="w-7 h-7" strokeWidth={3} />
             </button>

--- a/components/sheet/CharacterSheet.tsx
+++ b/components/sheet/CharacterSheet.tsx
@@ -177,10 +177,12 @@ const CharacterSheet: FC<Props> = ({
 
   if (collapsed) {
     return (
-      <aside
-        className="w-12 p-2 bg-black/10 border border-white/10 backdrop-blur-[2px] shadow shadow-black/5 rounded-2xl flex items-center justify-center transition-all duration-300"
-      >
-        <button onClick={onToggle} aria-label="Expand character panel" className="text-white">
+      <aside className="relative w-0 h-full">
+        <button
+          onClick={onToggle}
+          aria-label="Expand character panel"
+          className="absolute top-1/2 -translate-y-1/2 -right-6 p-2 rounded-full border border-white/10 bg-black/20 text-white"
+        >
           <ChevronRight />
         </button>
       </aside>
@@ -207,7 +209,7 @@ const CharacterSheet: FC<Props> = ({
       <button
         onClick={onToggle}
         aria-label="Collapse character panel"
-        className="absolute top-2 right-2 text-white"
+        className="absolute top-1/2 -translate-y-1/2 -right-6 p-2 rounded-full border border-white/10 bg-black/20 text-white"
       >
         <ChevronLeft />
       </button>


### PR DESCRIPTION
## Summary
- add local collapse state for character, chat, and dice panels
- add chevron toggles to hide or show each panel
- persist collapsed state with localStorage so layout preference remains

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6896269faa50832e9b682b0d9fefe038