### PR TITLE
feat: persist background selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ Backgrounds are handled through a global React context. To add a new animated ba
 
 The background switch button in the menu will then cycle through all available backgrounds.
 
+The currently selected background is saved in `localStorage` so it persists
+between page reloads. If a stored theme is not available, the default `rpg`
+background is used instead.
+

--- a/components/context/BackgroundContext.tsx
+++ b/components/context/BackgroundContext.tsx
@@ -3,6 +3,7 @@ import {
   createContext,
   useContext,
   useState,
+  useEffect,
   ReactNode,
   Dispatch,
   SetStateAction,
@@ -55,8 +56,23 @@ const BackgroundContext = createContext<BackgroundContextValue | undefined>(
 )
 
 export function BackgroundProvider({ children }: { children: ReactNode }) {
-  // état initial : 'rpg'
-  const [background, setBackground] = useState<BackgroundType>('rpg')
+  // état initial : 'rpg' (ou valeur sauvegardée en local)
+  const [background, setBackground] = useState<BackgroundType>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('background') as BackgroundType | null
+      if (stored && cycleOrder.includes(stored)) return stored
+    }
+    return 'rpg'
+  })
+
+  // 💾 Sauvegarde le background à chaque changement
+  useEffect(() => {
+    try {
+      localStorage.setItem('background', background)
+    } catch {
+      // ignore write errors
+    }
+  }, [background])
 
   // ⏩ Passe au background suivant dans cycleOrder
   const cycleBackground = () => {


### PR DESCRIPTION
## Summary
- persist selected background in `localStorage` with default fallback
- document background persistence in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689676ff2bdc832ebdb1adb33d065b4f