### PR TITLE
feat: replace native dialogs with custom modals

### DIFF
--- a/components/ClientLayout.tsx
+++ b/components/ClientLayout.tsx
@@ -2,14 +2,17 @@
 import BackgroundWrapper from '@/components/ui/BackgroundWrapper'
 import { BackgroundProvider } from '@/components/context/BackgroundContext'
 import { LanguageProvider } from '@/components/context/LanguageContext'
+import { DialogProvider } from '@/components/context/DialogContext'
 
 export default function ClientLayout({ children }: { children: React.ReactNode }) {
   return (
     <LanguageProvider>
-      <BackgroundProvider>
-        <BackgroundWrapper />
-        <main className="relative z-10">{children}</main>
-      </BackgroundProvider>
+      <DialogProvider>
+        <BackgroundProvider>
+          <BackgroundWrapper />
+          <main className="relative z-10">{children}</main>
+        </BackgroundProvider>
+      </DialogProvider>
     </LanguageProvider>
   )
 }

--- a/components/character/ImportExportMenu.tsx
+++ b/components/character/ImportExportMenu.tsx
@@ -5,6 +5,7 @@ import { FC, useRef, useState, useEffect } from 'react'
 import { useT } from '@/lib/useT'
 import { Folder } from 'lucide-react'
 import { defaultPerso } from '../sheet/CharacterSheet'
+import { useDialog } from '@/components/context/DialogContext'
 
 type Props = {
   perso: any,
@@ -36,6 +37,7 @@ const ImportExportMenu: FC<Props> = ({ perso, onUpdate }) => {
   const [localChars, setLocalChars] = useState<any[]>([])
   const inputRef = useRef<HTMLInputElement>(null)
   const t = useT()
+  const dialog = useDialog()
 
   useEffect(() => {
     if (!modal) return
@@ -78,9 +80,9 @@ const ImportExportMenu: FC<Props> = ({ perso, onUpdate }) => {
         if (!data || typeof data !== "object") throw new Error()
         onUpdate(data)
         addToList({ ...data, id: data.id || crypto.randomUUID() })
-        alert(t('importSuccess'))
+        void dialog.alert(t('importSuccess'))
       } catch {
-        alert(t('importFail'))
+        void dialog.alert(t('importFail'))
         // onUpdate({ ...defaultPerso }) // Optionnel : reset fiche si import KO
       }
     }
@@ -91,7 +93,7 @@ const ImportExportMenu: FC<Props> = ({ perso, onUpdate }) => {
   // Sauvegarde locale
   const handleLocalSave = () => {
     localStorage.setItem(LOCAL_KEY, JSON.stringify(perso))
-    alert(t('saveLocallyMsg'))
+    void dialog.alert(t('saveLocallyMsg'))
     setOpen(false)
   }
 
@@ -104,13 +106,13 @@ const ImportExportMenu: FC<Props> = ({ perso, onUpdate }) => {
         if (!obj || typeof obj !== "object") throw new Error()
         onUpdate(obj)
         addToList({ ...obj, id: obj.id || crypto.randomUUID() })
-        alert(t('loadLocalSuccess'))
+        void dialog.alert(t('loadLocalSuccess'))
       } catch {
-        alert(t('loadLocalFail'))
+        void dialog.alert(t('loadLocalFail'))
         // onUpdate({ ...defaultPerso }) // Optionnel : reset si load KO
       }
     } else {
-      alert(t('noSave'))
+      void dialog.alert(t('noSave'))
     }
     setOpen(false)
   }
@@ -122,7 +124,7 @@ const ImportExportMenu: FC<Props> = ({ perso, onUpdate }) => {
       method: 'POST',
       body: JSON.stringify(char),
     })
-    alert(t('saveCloud'))
+    void dialog.alert(t('saveCloud'))
     setModal(null)
   }
 
@@ -136,9 +138,9 @@ const ImportExportMenu: FC<Props> = ({ perso, onUpdate }) => {
       const obj = JSON.parse(txt)
       onUpdate(obj)
       addToList({ ...obj, id: obj.id || crypto.randomUUID() })
-      alert(t('loadCloudSuccess'))
+      void dialog.alert(t('loadCloudSuccess'))
     } catch {
-      alert(t('loadCloudFail'))
+      void dialog.alert(t('loadCloudFail'))
     }
     setModal(null)
   }
@@ -146,13 +148,13 @@ const ImportExportMenu: FC<Props> = ({ perso, onUpdate }) => {
   const deleteFromCloud = async (filename: string) => {
     await fetch(`/api/blop/delete?filename=${encodeURIComponent(filename)}`)
     setCloudFiles(f => f.filter(fl => fl !== filename))
-    alert(t('deleted'))
+    void dialog.alert(t('deleted'))
     setModal(null)
   }
 
   // Reset sheet
-  const handleReset = () => {
-    if (window.confirm("Really reset the sheet? (This will delete it)")) {
+  const handleReset = async () => {
+    if (await dialog.confirm("Really reset the sheet? (This will delete it)")) {
       onUpdate({ ...defaultPerso })
       setOpen(false)
     }

--- a/components/context/DialogContext.tsx
+++ b/components/context/DialogContext.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState, ReactNode, useCallback } from 'react'
+import Portal from '@/components/Portal'
+import { useT } from '@/lib/useT'
+
+type AlertState = { type: 'alert'; message: string; resolve: () => void }
+type ConfirmState = { type: 'confirm'; message: string; resolve: (v: boolean) => void }
+type PromptState = {
+  type: 'prompt'
+  message: string
+  value: string
+  resolve: (v: string | null) => void
+}
+
+type DialogState = AlertState | ConfirmState | PromptState | null
+
+interface DialogContextType {
+  alert: (msg: string) => Promise<void>
+  confirm: (msg: string) => Promise<boolean>
+  prompt: (msg: string, def?: string) => Promise<string | null>
+}
+
+const DialogContext = createContext<DialogContextType | null>(null)
+
+export function DialogProvider({ children }: { children: ReactNode }) {
+  const t = useT()
+  const [state, setState] = useState<DialogState>(null)
+
+  const alert = (msg: string) =>
+    new Promise<void>(resolve => setState({ type: 'alert', message: msg, resolve }))
+
+  const confirm = (msg: string) =>
+    new Promise<boolean>(resolve => setState({ type: 'confirm', message: msg, resolve }))
+
+  const prompt = (msg: string, def = '') =>
+    new Promise<string | null>(resolve => setState({ type: 'prompt', message: msg, value: def, resolve }))
+
+  const close = () => setState(null)
+
+  const handleConfirm = useCallback(() => {
+    if (!state) return
+    switch (state.type) {
+      case 'alert':
+        state.resolve()
+        break
+      case 'confirm':
+        state.resolve(true)
+        break
+      case 'prompt':
+        state.resolve(state.value)
+        break
+    }
+    close()
+  }, [state])
+
+  const handleCancel = useCallback(() => {
+    if (!state) return
+    switch (state.type) {
+      case 'alert':
+        state.resolve()
+        break
+      case 'confirm':
+        state.resolve(false)
+        break
+      case 'prompt':
+        state.resolve(null)
+        break
+    }
+    close()
+  }, [state])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') handleCancel()
+      if (e.key === 'Enter' && state && state.type !== 'prompt') handleConfirm()
+    }
+    if (state) document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [state, handleCancel, handleConfirm])
+
+  const value = { alert, confirm, prompt }
+
+  return (
+    <DialogContext.Provider value={value}>
+      {children}
+      {state && (
+        <Portal>
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center p-4"
+            style={{ background: 'rgba(0,0,0,0.45)', backdropFilter: 'blur(2px)' }}
+            onClick={handleCancel}
+            role="dialog"
+            aria-modal="true"
+          >
+            <div
+              onClick={e => e.stopPropagation()}
+              className="bg-black/80 text-white rounded-2xl border border-white/10 shadow-2xl backdrop-blur-md p-5 w-80"
+            >
+              <p className="mb-4 whitespace-pre-wrap">{state.message}</p>
+              {state.type === 'prompt' && (
+                <input
+                  autoFocus
+                  className="w-full mb-4 px-2 py-1 rounded bg-gray-800 text-white border border-white/20 focus:outline-none focus:ring-2 focus:ring-pink-400/30"
+                  value={state.value}
+                  onChange={e => setState(s => (s && s.type === 'prompt') ? { ...s, value: e.target.value } : s)}
+                  onKeyDown={e => { if (e.key === 'Enter') handleConfirm() }}
+                />
+              )}
+              <div className="flex justify-end gap-2">
+                {state.type !== 'alert' && (
+                  <button
+                    onClick={handleCancel}
+                    className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600"
+                  >
+                    {t('cancel')}
+                  </button>
+                )}
+                <button
+                  onClick={handleConfirm}
+                  autoFocus={state.type !== 'prompt'}
+                  className="px-3 py-1 rounded bg-emerald-600 hover:bg-emerald-500"
+                >
+                  {t('confirm')}
+                </button>
+              </div>
+            </div>
+          </div>
+        </Portal>
+      )}
+    </DialogContext.Provider>
+  )
+}
+
+export function useDialog() {
+  const ctx = useContext(DialogContext)
+  if (!ctx) throw new Error('useDialog must be used within DialogProvider')
+  return ctx
+}
+

--- a/components/menu/MenuAccueil.tsx
+++ b/components/menu/MenuAccueil.tsx
@@ -16,6 +16,7 @@ import MenuHeader from './MenuHeader'
 import CharacterList from './CharacterList'
 import CharacterModal from './CharacterModal'
 import ProfileColorPicker from './ProfileColorPicker'
+import { useDialog } from '@/components/context/DialogContext'
 
 const PROFILE_KEY = 'jdr_profile'
 const SELECTED_KEY = 'selectedCharacterId'
@@ -34,6 +35,7 @@ type Character = {
 export default function MenuAccueil() {
   const router = useRouter()
   const t = useT()
+  const dialog = useDialog()
   const [user, setUser] = useState<{ pseudo:string; isMJ:boolean; color:string } | null>(null)
   const [characters, setCharacters]   = useState<Character[]>([])
   const [selectedIdx, setSelectedIdx] = useState<number | null>(null)
@@ -193,8 +195,8 @@ export default function MenuAccueil() {
     setSelectedIdx(updated.findIndex(c => c.id === id))
   }
 
-  const handleDeleteChar = (id: string | number) => {
-    if (!window.confirm(t('deleteSheetConfirm'))) return
+  const handleDeleteChar = async (id: string | number) => {
+    if (!await dialog.confirm(t('deleteSheetConfirm'))) return
     const idx = characters.findIndex(c => String(c.id) === String(id))
     if (idx === -1) return
     const toDelete = characters[idx]
@@ -228,8 +230,10 @@ export default function MenuAccueil() {
         saveCharacters([...characters, withId])
         localStorage.setItem(SELECTED_KEY, String(id))
         setSelectedIdx(characters.length)
-        alert(t('importSuccess'))
-      } catch { alert(t('invalidFile')) }
+        void dialog.alert(t('importSuccess'))
+      } catch {
+        void dialog.alert(t('invalidFile'))
+      }
     }
     reader.readAsText(file)
     e.target.value = ''
@@ -265,7 +269,7 @@ export default function MenuAccueil() {
 
   const handleDeleteCloudChar = async (id: string | number) => {
     if (!selectedRoom) return
-    if (!window.confirm('Delete from cloud?')) return
+    if (!await dialog.confirm('Delete from cloud?')) return
     await fetch(`/api/roomstorage?roomId=${encodeURIComponent(selectedRoom.id)}&id=${encodeURIComponent(String(id))}`, { method: 'DELETE' })
     setRemoteChars(r => {
       const next = { ...r }

--- a/components/rooms/RoomList.tsx
+++ b/components/rooms/RoomList.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { useT } from '@/lib/useT'
 import { Lock } from 'lucide-react'
 import RoomAvatarStack from './RoomAvatarStack'
+import { useDialog } from '@/components/context/DialogContext'
 
 export type RoomInfo = {
   id: string
@@ -35,6 +36,7 @@ export default function RoomList({ onSelect, selectedId, onCreateClick }: Props)
   const [revealIds, setRevealIds] = useState<Record<string, boolean>>({})
   const [verifying, setVerifying] = useState(false)
   const t = useT()
+  const dialog = useDialog()
 
   useEffect(() => {
     const update = () => {
@@ -49,7 +51,7 @@ export default function RoomList({ onSelect, selectedId, onCreateClick }: Props)
   }, [])
 
   const deleteRoom = async (room: RoomInfo) => {
-    if (!window.confirm(t('deleteRoomConfirm'))) return
+    if (!await dialog.confirm(t('deleteRoomConfirm'))) return
     await fetch('/api/rooms', {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
@@ -64,7 +66,7 @@ export default function RoomList({ onSelect, selectedId, onCreateClick }: Props)
   }
 
   const renameRoom = async (room: RoomInfo) => {
-    const newName = window.prompt('Nouveau nom ?', room.name)
+    const newName = await dialog.prompt('Nouveau nom ?', room.name)
     if (!newName || newName === room.name) return
     await fetch('/api/rooms', {
       method: 'PATCH',


### PR DESCRIPTION
## Summary
- add DialogProvider with custom alert, confirm and prompt modals
- integrate dialog provider in client layout
- replace window alerts/prompts/confirms across components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68967ad21ca4832e9d306e63105f139b