### PR TITLE
fix: stabilize keys and add error boundaries

### DIFF
--- a/components/app/HomePageInner.tsx
+++ b/components/app/HomePageInner.tsx
@@ -18,6 +18,7 @@ import useDiceHistory from './hooks/useDiceHistory'
 import useEventLog from './hooks/useEventLog'
 import useProfile from './hooks/useProfile'
 import useOnlineStatus from './hooks/useOnlineStatus'
+import ErrorBoundary from '@/components/misc/ErrorBoundary'
 
 export default function HomePageInner() {
   const router = useRouter()
@@ -179,19 +180,27 @@ export default function HomePageInner() {
 
         <main className="flex-1 flex flex-col min-h-0">
           <div className="flex-1 m-4 flex flex-col justify-center items-center relative min-h-0">
-            <InteractiveCanvas />
-            <PopupResult show={showPopup} result={diceResult} diceType={diceType} onReveal={handlePopupReveal} onFinish={handlePopupFinish} />
+            <ErrorBoundary fallback={<div className="p-4 text-red-500">Canvas error</div>}>
+              <InteractiveCanvas />
+            </ErrorBoundary>
+            <ErrorBoundary fallback={<div className="p-4 text-red-500">Dice display error</div>}>
+              <PopupResult show={showPopup} result={diceResult} diceType={diceType} onReveal={handlePopupReveal} onFinish={handlePopupFinish} />
+            </ErrorBoundary>
           </div>
-          <DiceRoller diceType={diceType} onChange={setDiceType} onRoll={rollDice} disabled={diceDisabled} cooldown={cooldown} cooldownDuration={ROLL_TOTAL_MS}>
-            <LiveAvatarStack />
-          </DiceRoller>
+          <ErrorBoundary fallback={<div className="p-4 text-red-500">Dice roller error</div>}>
+            <DiceRoller diceType={diceType} onChange={setDiceType} onRoll={rollDice} disabled={diceDisabled} cooldown={cooldown} cooldownDuration={ROLL_TOTAL_MS}>
+              <LiveAvatarStack />
+            </DiceRoller>
+          </ErrorBoundary>
         </main>
 
-        <ChatBox
-          chatBoxRef={chatBoxRef}
-          history={history}
-          author={perso.nom || profile?.pseudo || 'Anonymous'}
-        />
+        <ErrorBoundary fallback={<div className="p-4 text-red-500">Chat error</div>}>
+          <ChatBox
+            chatBoxRef={chatBoxRef}
+            history={history}
+            author={perso.nom || profile?.pseudo || 'Anonymous'}
+          />
+        </ErrorBoundary>
         <SideNotes />
       </div>
       <Head>

--- a/components/character/AddCompetenceModal.tsx
+++ b/components/character/AddCompetenceModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { useT } from '@/lib/useT'
 
 export type NewCompetence = {
+    id: string;
     nom: string;
     type: string;
     effets: string;
@@ -39,6 +40,7 @@ export const AddCompetenceModal: React.FC<AddCompetenceModalProps> = ({
     const handleAdd = () => {
         if (!nom || !type || !effets) return;
         onAdd({
+            id: crypto.randomUUID(),
             nom,
             type,
             effets,

--- a/components/character/CharacterSheetHeader.tsx
+++ b/components/character/CharacterSheetHeader.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, ReactElement } from 'react'
 import { useT } from '@/lib/useT'
 import Link from 'next/link'
 import CakeLogo from '../ui/CakeLogo'
@@ -67,9 +67,10 @@ const CharacterSheetHeader: FC<Props> = ({
         >
           {edit ? t('save') : t('edit')}
         </button>
-        {childrenArray.map((child, i) => (
-          <span key={i} className="flex items-center">{child}</span>
-        ))}
+        {childrenArray.map((child, i) => {
+          const key = (child as ReactElement)?.key ?? `child-${i}`
+          return <span key={String(key)} className="flex items-center">{child}</span>
+        })}
       </div>
       <nav className="flex gap-2 mt-2">
         {TABS.map(t => (

--- a/components/character/CompetencesPanel.tsx
+++ b/components/character/CompetencesPanel.tsx
@@ -4,13 +4,13 @@ import { FC, useState } from 'react'
 import AddCompetenceModal from './AddCompetenceModal'
 import { useT } from '@/lib/useT'
 
-type Competence = { nom: string, type: string, effets: string, degats?: string }
+type Competence = { id: string; nom: string; type: string; effets: string; degats?: string }
 
 type Props = {
   competences: Competence[],
   edit: boolean,
   onAdd: (comp: Competence) => void,
-  onDelete: (index: number) => void,
+  onDelete: (id: string) => void,
 }
 
 const CompetencesPanel: FC<Props> = ({ competences = [], edit, onAdd, onDelete }) => {
@@ -23,11 +23,11 @@ const CompetencesPanel: FC<Props> = ({ competences = [], edit, onAdd, onDelete }
       {edit ? (
         <>
           <div className="flex flex-col gap-2 mb-2">
-            {competences.map((c, i) => (
-              <div key={i} className="bg-gray-800 rounded px-2 py-1 flex flex-col relative">
+            {competences.map((c) => (
+              <div key={c.id} className="bg-gray-800 rounded px-2 py-1 flex flex-col relative">
                 <div className="font-semibold">{c.nom} <span className="text-xs italic text-gray-300">({c.type})</span></div>
                 <div className="text-xs">{t('effects')}: {c.effets} {c.degats && <span>- {t('damageOptional').replace(' (optional)','')}: {c.degats}</span>}</div>
-                <button className="absolute top-1 right-2 text-xs text-red-400 hover:underline" onClick={() => onDelete(i)}>{t('delete')}</button>
+                <button className="absolute top-1 right-2 text-xs text-red-400 hover:underline" onClick={() => onDelete(c.id)}>{t('delete')}</button>
               </div>
             ))}
           </div>
@@ -46,8 +46,8 @@ const CompetencesPanel: FC<Props> = ({ competences = [], edit, onAdd, onDelete }
         </>
       ) : (
         <div className="flex flex-col gap-1">
-          {competences.map((c, i) => (
-            <div key={i} className="bg-gray-800 rounded px-2 py-1">
+          {competences.map((c) => (
+            <div key={c.id} className="bg-gray-800 rounded px-2 py-1">
               <div className="font-semibold">{c.nom} <span className="text-xs italic text-gray-300">({c.type})</span></div>
               <div className="text-xs">{t('effects')}: {c.effets} {c.degats && <span>- {t('damageOptional').replace(' (optional)','')}: {c.degats}</span>}</div>
             </div>

--- a/components/character/DescriptionPanel.tsx
+++ b/components/character/DescriptionPanel.tsx
@@ -5,7 +5,7 @@ import { FC, useState } from 'react'
 import { useT } from '@/lib/useT'
 import type { TranslationKey } from '@/lib/translations'
 
-type CustomField = { label: string, value: string }
+type CustomField = { id: string; label: string; value: string }
 
 type DescriptionValues = {
   race: string,
@@ -32,8 +32,8 @@ type DescriptionPanelProps = {
   onChange: (field: string, value: any) => void,
   champsPerso: CustomField[],
   onAddChamp: (champ: CustomField) => void,
-  onDelChamp: (index: number) => void,
-  onUpdateChamp: (index: number, champ: CustomField) => void,
+  onDelChamp: (id: string) => void,
+  onUpdateChamp: (id: string, champ: CustomField) => void,
 }
 
 // See more / close with translation
@@ -196,13 +196,13 @@ const DescriptionPanel: FC<DescriptionPanelProps> = ({
         {edit ? (
           <>
             <div className="flex flex-col gap-1 mb-1">
-              {champsPerso.map((f, i) => (
-                <div key={i} className="grid grid-cols-[120px_18px_1fr_80px] gap-1 mb-1 items-start w-full">
+            {champsPerso.map((f) => (
+                <div key={f.id} className="grid grid-cols-[120px_18px_1fr_80px] gap-1 mb-1 items-start w-full">
                   <input
                     className="p-1 rounded bg-white text-black text-sm w-full text-right"
                     value={f.label}
                     onChange={e => {
-                      onUpdateChamp(i, { ...f, label: e.target.value })
+                      onUpdateChamp(f.id, { ...f, label: e.target.value })
                     }}
                   />
                   <span className="text-right font-bold">:</span>
@@ -210,11 +210,11 @@ const DescriptionPanel: FC<DescriptionPanelProps> = ({
                     className="p-1 rounded bg-white text-black text-sm flex-1 min-h-[28px] resize-y w-full pl-3"
                     value={f.value}
                     onChange={e => {
-                      onUpdateChamp(i, { ...f, value: e.target.value })
+                      onUpdateChamp(f.id, { ...f, value: e.target.value })
                     }}
                     style={{ overflowWrap: 'break-word', minWidth: 0 }}
                   />
-                  <button className="text-xs text-red-400 hover:underline col-span-1 justify-self-end" onClick={() => onDelChamp(i)}>{t('delete')}</button>
+                  <button className="text-xs text-red-400 hover:underline col-span-1 justify-self-end" onClick={() => onDelChamp(f.id)}>{t('delete')}</button>
                 </div>
               ))}
             </div>
@@ -240,7 +240,7 @@ const DescriptionPanel: FC<DescriptionPanelProps> = ({
                 className="bg-blue-600 hover:bg-blue-700 text-white text-sm rounded p-1 mt-1 w-fit self-end"
                 onClick={() => {
                   if (!newChamp.label || !newChamp.value) return
-                  onAddChamp({ label: newChamp.label, value: newChamp.value })
+                  onAddChamp({ id: crypto.randomUUID(), label: newChamp.label, value: newChamp.value })
                   setNewChamp({})
                 }}
               >
@@ -250,8 +250,8 @@ const DescriptionPanel: FC<DescriptionPanelProps> = ({
           </>
         ) : (
           <div className="flex flex-col gap-1">
-            {champsPerso.map((f, i) => (
-              <div key={i} className="grid grid-cols-[120px_18px_1fr] items-start w-full">
+            {champsPerso.map((f) => (
+              <div key={f.id} className="grid grid-cols-[120px_18px_1fr] items-start w-full">
                 <span className="font-semibold text-right">{f.label}</span>
                 <span className="text-right font-bold">:</span>
                 <span className="break-words flex-1 pl-3">{f.value}</span>

--- a/components/character/EquipPanel.tsx
+++ b/components/character/EquipPanel.tsx
@@ -4,7 +4,7 @@
 import { FC, useState } from 'react'
 import { useT } from '@/lib/useT'
 
-type Objet = { nom: string, quantite: number }
+type Objet = { id: string; nom: string; quantite: number }
 
 type Props = {
   edit: boolean,
@@ -14,7 +14,7 @@ type Props = {
   modif_armure: number,
   objets: Objet[],
   onAddObj: (obj: Objet) => void,
-  onDelObj: (idx: number) => void,
+  onDelObj: (id: string) => void,
   onChange: (field: string, value: any) => void,
 }
 
@@ -36,7 +36,7 @@ const EquipPanel: FC<Props> = ({
     if (!newObj.nom || !newObj.quantite) return
     const quantiteNumber = parseInt(newObj.quantite, 10)
     if (isNaN(quantiteNumber) || quantiteNumber < 1) return
-    onAddObj({ nom: newObj.nom, quantite: quantiteNumber })
+    onAddObj({ id: crypto.randomUUID(), nom: newObj.nom, quantite: quantiteNumber })
     setNewObj({ nom: '', quantite: '' })
   }
 
@@ -76,11 +76,11 @@ const EquipPanel: FC<Props> = ({
       {edit ? (
         <>
           <div className="flex flex-col gap-1 mb-2">
-            {objets.map((o, i) => (
-              <div key={i} className="flex items-center gap-2 bg-gray-800 rounded px-2 py-1">
+            {objets.map((o) => (
+              <div key={o.id} className="flex items-center gap-2 bg-gray-800 rounded px-2 py-1">
                 <span className="text-base">{o.nom}</span>
                 <span className="text-xs text-gray-300">x{o.quantite}</span>
-                <button className="text-xs text-red-400 hover:underline ml-2" onClick={() => onDelObj(i)}>{t('delete')}</button>
+                <button className="text-xs text-red-400 hover:underline ml-2" onClick={() => onDelObj(o.id)}>{t('delete')}</button>
               </div>
             ))}
           </div>
@@ -109,8 +109,8 @@ const EquipPanel: FC<Props> = ({
         </>
       ) : (
         <div className="flex flex-col gap-1">
-          {objets.map((o, i) => (
-            <div key={i} className="flex items-center gap-2 bg-gray-800 rounded px-2 py-1">
+          {objets.map((o) => (
+            <div key={o.id} className="flex items-center gap-2 bg-gray-800 rounded px-2 py-1">
               <span className="text-base">{o.nom}</span>
               <span className="text-xs text-gray-300">x{o.quantite}</span>
             </div>

--- a/components/login/Login.tsx
+++ b/components/login/Login.tsx
@@ -31,11 +31,11 @@ function DicePips({ value, size }: { value:number; size:number }) {
   const gap = (size - 3 * dotSize)/4
   return (
     <div style={{ position:'relative', width:size, height:size, pointerEvents:'none' }} aria-label={`Face ${value}`}>
-      {pipPattern(value).map((d,i)=>{
+      {pipPattern(value).map(d=>{
         const top = gap + d.r*(dotSize+gap)
         const left= gap + d.c*(dotSize+gap)
         return (
-          <div key={i} style={{
+          <div key={`${d.r}-${d.c}`} style={{
             position:'absolute', top, left, width:dotSize, height:dotSize,
             borderRadius:'50%',
             background:'radial-gradient(circle at 30% 30%, #fff, #bbb 70%)',
@@ -186,9 +186,9 @@ transition: 'opacity 0.4s ease, transform 0.3s ease'
 
             }}
           >
-            {faces.map(({ rotX, rotY, type, value }, idx) => (
+            {faces.map(({ rotX, rotY, type, value }) => (
               <div
-                key={idx}
+                key={`${type}-${value}`}
                 style={{
                   position:'absolute',
                   width:CUBE_SIZE,

--- a/components/menu/CharacterList.tsx
+++ b/components/menu/CharacterList.tsx
@@ -81,7 +81,7 @@ const CharacterList: FC<Props> = ({
         return (
         <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
           <AnimatePresence initial={false}>
-          {all.map((ch, idx) => {
+          {all.map((ch) => {
             const isSelected = selectedIdx !== null && filtered[selectedIdx]?.id === ch.id
             const localIdx = filtered.findIndex(c => String(c.id) === String(ch.id))
             const local = localIdx !== -1
@@ -92,7 +92,7 @@ const CharacterList: FC<Props> = ({
             const needsUpload = local && (!cloud || (localChar?.updatedAt || 0) > (cloudChar?.updatedAt || 0))
             return (
               <motion.li
-                key={`${ch.id}-${idx}`}
+                key={ch.id}
                 onClick={() => onSelect(local ? filtered.findIndex(c => String(c.id)===String(ch.id)) : -1)}
                 className={`
                   group relative rounded-lg p-3 cursor-pointer

--- a/components/menu/CharacterModal.tsx
+++ b/components/menu/CharacterModal.tsx
@@ -6,8 +6,8 @@ import StatsPanel from "../character/StatsPanel"
 import EquipPanel from "../character/EquipPanel"
 import DescriptionPanel from "../character/DescriptionPanel"
 import CompetencesPanel from "../character/CompetencesPanel" // ← Le bon nom !
-type Competence = { nom: string; type: string; effets: string; degats?: string }
-type Objet = { nom: string; quantite: number }
+type Competence = { id: string; nom: string; type: string; effets: string; degats?: string }
+type Objet = { id: string; nom: string; quantite: number }
 type DescriptionValues = {
   race: string
   classe: string
@@ -23,7 +23,7 @@ type DescriptionValues = {
   failles: string
   avantages: string
   background: string
-  champs_perso: { label: string; value: string }[]
+  champs_perso: { id: string; label: string; value: string }[]
   [key: string]: unknown
 }
 
@@ -105,11 +105,11 @@ const CharacterModal: FC<Props> = ({
                   objets={(character.objets as Objet[]) || []}
                   onChange={handlePanelChange}
                   onAddObj={(obj) => {
-                    const objets = [...((character.objets as Objet[]) || []), obj]
+                    const objets = [...((character.objets as Objet[]) || []), { ...obj, id: crypto.randomUUID() }]
                     handlePanelChange("objets", objets)
                   }}
-                  onDelObj={(idx) => {
-                    const objets = ((character.objets as Objet[]) || []).filter((_, i) => i !== idx)
+                  onDelObj={(id) => {
+                    const objets = ((character.objets as Objet[]) || []).filter((o) => o.id !== id)
                     handlePanelChange("objets", objets)
                   }}
                 />
@@ -126,8 +126,8 @@ const CharacterModal: FC<Props> = ({
                     const nv = [...((character.competences as Competence[]) || []), comp]
                     handlePanelChange("competences", nv)
                   }}
-                  onDelete={(idx) => {
-                    const nv = ((character.competences as Competence[]) || []).filter((_, i) => i !== idx)
+                  onDelete={(id) => {
+                    const nv = ((character.competences as Competence[]) || []).filter((c) => c.id !== id)
                     handlePanelChange("competences", nv)
                   }}
                 />
@@ -145,24 +145,24 @@ const CharacterModal: FC<Props> = ({
                 values={character as unknown as DescriptionValues}
                 edit={true}
                 onChange={handlePanelChange}
-                champsPerso={(character.champs_perso as { label: string; value: string }[]) ?? []}
+                champsPerso={(character.champs_perso as { id: string; label: string; value: string }[]) ?? []}
                 onAddChamp={champ =>
                   handlePanelChange(
                     "champs_perso",
-                    [...((character.champs_perso as { label: string; value: string }[]) ?? []), champ]
+                    [...((character.champs_perso as { id: string; label: string; value: string }[]) ?? []), champ]
                   )
                 }
-                onDelChamp={i =>
+                onDelChamp={id =>
                   handlePanelChange(
                     "champs_perso",
-                    ((character.champs_perso as { label: string; value: string }[]) ?? []).filter((_, idx) => idx !== i)
+                    ((character.champs_perso as { id: string; label: string; value: string }[]) ?? []).filter(c => c.id !== id)
                   )
                 }
-                onUpdateChamp={(i, champ) =>
+                onUpdateChamp={(id, champ) =>
                   handlePanelChange(
                     "champs_perso",
-                    ((character.champs_perso as { label: string; value: string }[]) ?? []).map((c, idx) =>
-                      idx === i ? champ : c
+                    ((character.champs_perso as { id: string; label: string; value: string }[]) ?? []).map(c =>
+                      c.id === id ? champ : c
                     )
                   )
                 }

--- a/components/misc/ErrorBoundary.tsx
+++ b/components/misc/ErrorBoundary.tsx
@@ -1,0 +1,34 @@
+'use client'
+import React from 'react'
+
+interface Props {
+  children: React.ReactNode
+  fallback?: React.ReactNode
+}
+
+interface State { hasError: boolean }
+
+export default class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error(error, info)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? (
+        <div className="p-4 text-red-500">Something went wrong.</div>
+      )
+    }
+    return this.props.children
+  }
+}
+

--- a/components/misc/GMCharacterSelector.tsx
+++ b/components/misc/GMCharacterSelector.tsx
@@ -99,7 +99,7 @@ export default function GMCharacterSelector({
           )}
           {chars.map((c, idx) => (
             <button
-              key={`${c.id}-${idx}`}
+              key={c.id}
               onClick={() => handleSelect(c.id)}
               className={`
                 w-full text-left px-4 py-2 rounded-xl text-base

--- a/components/sheet/CharacterSheet.tsx
+++ b/components/sheet/CharacterSheet.tsx
@@ -276,7 +276,7 @@ const CharacterSheet: FC<Props> = ({
             failles: localPerso.failles,
             avantages: localPerso.avantages,
             background: localPerso.background,
-            champs_perso: localPerso.champs_perso,
+          champs_perso: localPerso.champs_perso,
           }}
           onChange={handleChange}
           champsPerso={localPerso.champs_perso}
@@ -286,15 +286,17 @@ const CharacterSheet: FC<Props> = ({
               champs_perso: [...(localPerso.champs_perso || []), champ]
             })
           }}
-          onDelChamp={idx => {
-            const arr = [...(localPerso.champs_perso || [])]
-            arr.splice(idx, 1)
-            setLocalPerso({ ...localPerso, champs_perso: arr })
+          onDelChamp={id => {
+            setLocalPerso({
+              ...localPerso,
+              champs_perso: (localPerso.champs_perso || []).filter((c: any) => c.id !== id)
+            })
           }}
-          onUpdateChamp={(idx, champ) => {
-            const arr = [...(localPerso.champs_perso || [])]
-            arr[idx] = champ
-            setLocalPerso({ ...localPerso, champs_perso: arr })
+          onUpdateChamp={(id, champ) => {
+            setLocalPerso({
+              ...localPerso,
+              champs_perso: (localPerso.champs_perso || []).map((c: any) => c.id === id ? champ : c)
+            })
           }}
         />
       )}

--- a/components/sheet/EquipTab.tsx
+++ b/components/sheet/EquipTab.tsx
@@ -21,13 +21,13 @@ const EquipTab: FC<Props> = ({ edit, localPerso, setLocalPerso, onChange }) => (
     onAddObj={(obj) =>
       setLocalPerso({
         ...localPerso,
-        objets: [...(localPerso.objets || []), obj],
+        objets: [...(localPerso.objets || []), { ...obj, id: crypto.randomUUID() }],
       })
     }
-    onDelObj={(idx) =>
+    onDelObj={(id) =>
       setLocalPerso({
         ...localPerso,
-        objets: (localPerso.objets || []).filter((_: any, i: number) => i !== idx),
+        objets: (localPerso.objets || []).filter((o: any) => o.id !== id),
       })
     }
     onChange={onChange}

--- a/components/sheet/StatsTab.tsx
+++ b/components/sheet/StatsTab.tsx
@@ -45,11 +45,11 @@ const StatsTab: FC<Props> = ({
           competences: [...(localPerso.competences || []), comp],
         })
       }
-        onDelete={(idx) =>
-          setLocalPerso({
-            ...localPerso,
-            competences: (localPerso.competences || []).filter((_: any, i: number) => i !== idx),
-          })
+      onDelete={(id) =>
+        setLocalPerso({
+          ...localPerso,
+          competences: (localPerso.competences || []).filter((c: any) => c.id !== id),
+        })
       }
     />
     <LevelUpPanel


### PR DESCRIPTION
## Summary
- add reusable ErrorBoundary and wrap canvas, dice, and chat sections
- replace index-based keys with stable ids for equipment, competences, custom fields, and selectors
- use stable keys in login cube rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689680dc15fc832eb4f80257a72a02ab