### PR TITLE
feat: improve accessibility for custom modals

### DIFF
--- a/components/character/AddCompetenceModal.tsx
+++ b/components/character/AddCompetenceModal.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { useT } from '@/lib/useT'
+import useFocusTrap from '@/lib/useFocusTrap'
 
 export type NewCompetence = {
     nom: string;
@@ -35,6 +36,9 @@ export const AddCompetenceModal: React.FC<AddCompetenceModalProps> = ({
     const [type, setType] = useState(competenceTypes[0]);
     const [effets, setEffets] = useState("");
     const [degats, setDegats] = useState("");
+    const modalRef = useRef<HTMLDivElement>(null)
+
+    useFocusTrap(modalRef, open, onClose)
 
     const handleAdd = () => {
         if (!nom || !type || !effets) return;
@@ -54,15 +58,24 @@ export const AddCompetenceModal: React.FC<AddCompetenceModalProps> = ({
     if (!open) return null;
 
     return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: "rgba(0,0,0,0.2)" }}>
-            <div className="bg-gray-900 rounded-lg shadow-lg p-6 w-full max-w-md relative">
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center transition-opacity"
+            style={{ background: "rgba(0,0,0,0.2)" }}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="add-skill-title"
+        >
+            <div
+                ref={modalRef}
+                className="bg-gray-900 rounded-lg shadow-lg p-6 w-full max-w-md relative"
+            >
                 <button
                     className="absolute top-2 right-2 text-gray-400 hover:text-white"
                     onClick={onClose}
                 >
                     ✕
                 </button>
-                <div className="text-lg font-semibold mb-4">{t('addSkill')}</div>
+                <div id="add-skill-title" className="text-lg font-semibold mb-4">{t('addSkill')}</div>
                 <div className="flex flex-col gap-3">
                     <div>
                         <label className="block text-sm mb-1">{t('name')}</label>
@@ -112,7 +125,7 @@ export const AddCompetenceModal: React.FC<AddCompetenceModalProps> = ({
                         {t('cancel')}
                     </button>
                     <button
-                        className="bg-blue-600 hover:bg-blue-700 text-white rounded px-3 py-1"
+                        className="bg-blue-600 hover:bg-blue-700 text-white rounded px-3 py-1 disabled:opacity-50"
                         onClick={handleAdd}
                         disabled={!nom || !type || !effets}
                     >

--- a/components/menu/CharacterModal.tsx
+++ b/components/menu/CharacterModal.tsx
@@ -1,11 +1,12 @@
 'use client'
-import { FC } from "react"
+import { FC, useRef } from "react"
 import { useT } from '@/lib/useT'
 import { Character } from "./CharacterList"
 import StatsPanel from "../character/StatsPanel"
 import EquipPanel from "../character/EquipPanel"
 import DescriptionPanel from "../character/DescriptionPanel"
 import CompetencesPanel from "../character/CompetencesPanel" // ← Le bon nom !
+import useFocusTrap from '@/lib/useFocusTrap'
 type Competence = { nom: string; type: string; effets: string; degats?: string }
 type Objet = { nom: string; quantite: number }
 type DescriptionValues = {
@@ -43,6 +44,8 @@ const CharacterModal: FC<Props> = ({
   onClose,
 }) => {
   const t = useT()
+  const modalRef = useRef<HTMLDivElement>(null)
+  useFocusTrap(modalRef, open, onClose)
   if (!open || !character) return null
 
   const handlePanelChange = (field: string, value: unknown) => {
@@ -51,7 +54,7 @@ const CharacterModal: FC<Props> = ({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-2"
+      className="fixed inset-0 z-50 flex items-center justify-center p-2 transition-opacity"
       style={{
         background: "rgba(20,20,40,0.62)",
         backdropFilter: "blur(8px)",
@@ -59,8 +62,10 @@ const CharacterModal: FC<Props> = ({
       }}
       role="dialog"
       aria-modal="true"
+      aria-labelledby="character-modal-title"
     >
       <div
+        ref={modalRef}
         className="
           relative rounded-2xl shadow-xl flex flex-col w-full
           max-w-[98vw] xl:max-w-[2000px]
@@ -68,7 +73,7 @@ const CharacterModal: FC<Props> = ({
           px-3 sm:px-8 py-7 h-[94vh] max-h-[98vh] min-h-[480px]
         "
       >
-        <h2 className="text-2xl font-bold mb-5 tracking-wide text-white text-center">
+        <h2 id="character-modal-title" className="text-2xl font-bold mb-5 tracking-wide text-white text-center">
           {t('characterEditing')}
         </h2>
         {/* Flex column: panels scrollent, boutons fixes en bas */}

--- a/components/rooms/RoomCreateModal.tsx
+++ b/components/rooms/RoomCreateModal.tsx
@@ -1,7 +1,8 @@
 'use client'
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import type { RoomInfo } from './RoomList'
 import { useT } from '@/lib/useT'
+import useFocusTrap from '@/lib/useFocusTrap'
 
 interface Props {
   open: boolean
@@ -16,6 +17,9 @@ export default function RoomCreateModal({ open, onClose, onCreated }: Props) {
   const [creating, setCreating] = useState(false)
   const [errorMsg, setErrorMsg] = useState('')
   const t = useT()
+  const modalRef = useRef<HTMLDivElement>(null)
+
+  useFocusTrap(modalRef, open, onClose)
 
   if (!open) return null
 
@@ -56,9 +60,22 @@ export default function RoomCreateModal({ open, onClose, onCreated }: Props) {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4" onClick={onClose} style={{ background:'rgba(0,0,0,0.45)', backdropFilter:'blur(2px)' }}>
-      <div onClick={e => e.stopPropagation()} className="bg-black/80 text-white rounded-2xl border border-white/10 shadow-2xl backdrop-blur-md p-5 w-80">
-        <h2 className="text-lg font-semibold mb-2">{t('createRoom')}</h2>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 transition-opacity"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="room-create-title"
+      style={{ background: 'rgba(0,0,0,0.45)', backdropFilter: 'blur(2px)' }}
+    >
+      <div
+        ref={modalRef}
+        onClick={e => e.stopPropagation()}
+        className="bg-black/80 text-white rounded-2xl border border-white/10 shadow-2xl backdrop-blur-md p-5 w-80"
+      >
+        <h2 id="room-create-title" className="text-lg font-semibold mb-2">
+          {t('createRoom')}
+        </h2>
         <input
           className="w-full mb-2 px-2 py-1 rounded bg-gray-800 text-white border border-white/20 focus:outline-none focus:ring-2 focus:ring-pink-400/30"
           placeholder={t('name')}
@@ -85,19 +102,22 @@ export default function RoomCreateModal({ open, onClose, onCreated }: Props) {
           />
         )}
         {creating ? (
-          <div className="w-full h-2 bg-gray-700 rounded overflow-hidden mb-2">
-            <div className="h-full bg-emerald-500 animate-pulse" style={{ width:'100%' }} />
+          <div className="w-full h-2 bg-gray-700 rounded overflow-hidden mb-2" role="status" aria-live="polite">
+            <div className="h-full bg-emerald-500 animate-pulse" style={{ width: '100%' }} />
           </div>
         ) : (
           <button
-            className="w-full px-3 py-2 rounded-md bg-emerald-600 hover:bg-emerald-500 text-white font-semibold"
+            className="w-full px-3 py-2 rounded-md bg-emerald-600 hover:bg-emerald-500 text-white font-semibold disabled:opacity-50"
             onClick={createRoom}
+            disabled={!name}
           >
             {t('createRoom')}
           </button>
         )}
         {errorMsg && (
-          <p className="text-red-400 text-sm mt-2 text-center">{errorMsg}</p>
+          <p className="text-red-400 text-sm mt-2 text-center" role="alert" aria-live="assertive">
+            {errorMsg}
+          </p>
         )}
       </div>
     </div>

--- a/lib/useFocusTrap.ts
+++ b/lib/useFocusTrap.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react'
+
+export default function useFocusTrap(
+  containerRef: React.RefObject<HTMLElement>,
+  active: boolean,
+  onEscape?: () => void
+) {
+  useEffect(() => {
+    if (!active || !containerRef.current) return
+    const container = containerRef.current
+    const selectors =
+      'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    const focusable = Array.from(
+      container.querySelectorAll<HTMLElement>(selectors)
+    )
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    first?.focus()
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onEscape?.()
+        return
+      }
+      if (e.key !== 'Tab' || focusable.length === 0) return
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault()
+          ;(last || first).focus()
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault()
+          ;(first || last).focus()
+        }
+      }
+    }
+
+    container.addEventListener('keydown', handleKeyDown)
+    return () => {
+      container.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [active, containerRef, onEscape])
+}
+


### PR DESCRIPTION
## Summary
- add reusable focus trap hook
- wire focus trap and ARIA roles into modals
- expose loader and error live regions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689680f664ec832ea481faa8815f58d4