### PR TITLE
Fix notes button positioning and remove image hint

### DIFF
--- a/components/app/HomePageInner.tsx
+++ b/components/app/HomePageInner.tsx
@@ -11,7 +11,6 @@ import PopupResult from '@/components/dice/PopupResult'
 import Head from 'next/head'
 import InteractiveCanvas from '@/components/canvas/InteractiveCanvas'
 import LiveAvatarStack from '@/components/chat/LiveAvatarStack'
-import SideNotes from '@/components/misc/SideNotes'
 import Login from '@/components/login/Login'
 import GMCharacterSelector from '@/components/misc/GMCharacterSelector'
 import useDiceHistory from './hooks/useDiceHistory'
@@ -201,7 +200,6 @@ export default function HomePageInner() {
             author={perso.nom || profile?.pseudo || 'Anonymous'}
           />
         </ErrorBoundary>
-        <SideNotes />
       </div>
       <Head>
         <title>CakeJDR</title>

--- a/components/canvas/InteractiveCanvas.tsx
+++ b/components/canvas/InteractiveCanvas.tsx
@@ -9,6 +9,7 @@ import CanvasTools, { ToolMode } from './CanvasTools'
 import { useT } from '@/lib/useT'
 import MusicPanel from './MusicPanel'
 import ImageItem, { ImageData } from './ImageItem'
+import SideNotes from '@/components/misc/SideNotes'
 
 
 export default function InteractiveCanvas() {
@@ -469,13 +470,9 @@ export default function InteractiveCanvas() {
   />
 )}
 
-{images.length === 0 && (
-  <p className="absolute bottom-4 left-5 text-xs text-white/70 z-10">
-    Glisse une image ici
-  </p>
-)}
 
 <LiveCursors />
+<SideNotes />
 
 {/* DiceHub supprimé : les lancers de dés ne sont plus synchronisés globalement */}
 

--- a/components/misc/SideNotes.tsx
+++ b/components/misc/SideNotes.tsx
@@ -39,8 +39,7 @@ export default function SideNotes() {
 
   return (
     <div
-      className="fixed top-1/2 -translate-y-1/2 z-50"
-      style={{ left: 430 }}
+      className="absolute bottom-4 left-4 z-50"
     >
       {open ? (
         <div


### PR DESCRIPTION
## Summary
- move side notes button into canvas and anchor bottom-left
- remove image drag hint text from canvas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896899680b4832e9e8e35c935506490