### PR TITLE
feat: smooth day-night cycle

### DIFF
--- a/components/ClientLayout.tsx
+++ b/components/ClientLayout.tsx
@@ -15,14 +15,14 @@ class BackgroundErrorBoundary extends React.Component<
   { children: React.ReactNode },
   { hasError: boolean }
 > {
-  constructor(props: any) {
+  constructor(props: { children: React.ReactNode }) {
     super(props)
     this.state = { hasError: false }
   }
   static getDerivedStateFromError() {
     return { hasError: true }
   }
-  componentDidCatch(err: any) {
+  componentDidCatch(err: Error) {
     console.error('Background crashed:', err)
   }
   render() {

--- a/components/ui/SpecialBackground.tsx
+++ b/components/ui/SpecialBackground.tsx
@@ -17,7 +17,6 @@ function mulberry32(seed: number) {
 }
 const clamp = (v: number, a: number, b: number) => Math.max(a, Math.min(b, v))
 const lerp = (a: number, b: number, t: number) => a + (b - a) * t
-const smoothstep01 = (t: number) => { const x = clamp(t, 0, 1); return x * x * (3 - 2 * x) }
 function hexToRgb(hex?: string): [number, number, number] | null {
   if (typeof hex !== 'string') return null
   let h = hex.trim()

--- a/components/ui/SpecialBackground.tsx
+++ b/components/ui/SpecialBackground.tsx
@@ -387,7 +387,7 @@ export default function SpecialBackground() {
   const PLAIN_Y_MIN = 56, PLAIN_Y_MAX = 71
   const HEART_MS = 7000
 
-  const isDayNow = seconds >= 180
+  const isDayNow = seconds < moonStart
   function randomTargetPlain() {
     return { x: -8 + Math.random() * 116, y: PLAIN_Y_MIN + Math.random() * (PLAIN_Y_MAX - PLAIN_Y_MIN) }
   }

--- a/components/ui/SpecialBackground.tsx
+++ b/components/ui/SpecialBackground.tsx
@@ -39,7 +39,7 @@ function lerpColor(a?: string, b?: string, t = 0.5) {
   ])
 }
 
-// MODIF: petite fenêtre lissée (0 hors fenêtre, pic à 1 au centre) pour dawn/dusk
+// Smooth bell curve (0 outside the window, peak 1 at the center) for dawn/dusk blending
 function smoothWindow(x: number, a: number, b: number) {
   if (b <= a) return 0
   if (x <= a || x >= b) return 0


### PR DESCRIPTION
## Summary
- add precise sun and moon phases with transition delays
- smoothly blend sky colors through dawn and dusk
- fade star field based on night brightness

## Testing
- `npm test` *(fails: Unexpected any in ClientLayout.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689693452d4c832e8a1ad06f2484bbcc