### PR TITLE
fix: remove any types from background components

### DIFF
--- a/components/ui/Background9.tsx
+++ b/components/ui/Background9.tsx
@@ -205,7 +205,7 @@ function AuroraBlob({
         left: `${startX}vw`,
         top: `${startY}vh`,
         opacity,
-        mixBlendMode: blend as any,
+        mixBlendMode: blend as React.CSSProperties['mixBlendMode'],
         background: via
           ? `radial-gradient(60% 60% at 50% 50%, ${from} 0%, ${via} 40%, ${to} 70%, transparent 100%)`
           : `radial-gradient(60% 60% at 50% 50%, ${from} 0%, ${to} 70%, transparent 100%)`,
@@ -329,7 +329,7 @@ export default function Background9 () {
           height: '60vh',
           background:
             'radial-gradient(60% 60% at 50% 30%, rgba(59,130,246,0.18) 0%, rgba(59,130,246,0.08) 35%, transparent 70%)',
-          mixBlendMode: 'screen' as any,
+          mixBlendMode: 'screen' as React.CSSProperties['mixBlendMode'],
         }}
       />
     </div>

--- a/components/ui/BananaBackground.tsx
+++ b/components/ui/BananaBackground.tsx
@@ -27,18 +27,18 @@ export default function CakeBackground() {
       style={{
         // ====== VARIABLES TWEAK ======
         // Couleurs principales (tissu)
-        ['--bg' as any]: '#13161c',                   // fond global sous la trame
-        ['--fiber-dark' as any]: 'rgba(220,225,230,0.14)',
-        ['--fiber-light' as any]: 'rgba(255,255,255,0.06)',
+        '--bg': '#13161c',                   // fond global sous la trame
+        '--fiber-dark': 'rgba(220,225,230,0.14)',
+        '--fiber-light': 'rgba(255,255,255,0.06)',
         // Pas de fibre (contrôle densité)
-        ['--fiber-w' as any]: '2px',                  // largeur d'une fibre
-        ['--fiber-gap' as any]: '6px',                // écart entre fibres
+        '--fiber-w': '2px',                  // largeur d'une fibre
+        '--fiber-gap': '6px',                // écart entre fibres
         // Reflet (sheen)
-        ['--sheen' as any]: 'rgba(255,255,230,0.10)',
-        ['--sheen-size' as any]: '60vmin',
-        ['--sheen-blur' as any]: '22px',
+        '--sheen': 'rgba(255,255,230,0.10)',
+        '--sheen-size': '60vmin',
+        '--sheen-blur': '22px',
         // Vitesse de balayage
-        ['--speed' as any]: '18s',
+        '--speed': '18s',
       }}
     >
       {/* Couche 0 — Fond de base */}

--- a/components/ui/BananaBackground.tsx
+++ b/components/ui/BananaBackground.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 /**
- * CakeBackground — Fibres tressées (v1)
+ * BananaBackground — Fibres tressées (v1)
  * =====================================
  * ✅ Fond original & simple : trame de fibres diagonales (effet lin/ramie).
  * ✅ 100% CSS (gradients), zéro asset, ultra-perf.
@@ -19,7 +19,19 @@
 
 import React from 'react'
 
-export default function CakeBackground() {
+interface WeaveVars extends React.CSSProperties {
+  '--bg': string
+  '--fiber-dark': string
+  '--fiber-light': string
+  '--fiber-w': string
+  '--fiber-gap': string
+  '--sheen': string
+  '--sheen-size': string
+  '--sheen-blur': string
+  '--speed': string
+}
+
+export default function BananaBackground() {
   return (
     <div
       aria-hidden
@@ -39,7 +51,7 @@ export default function CakeBackground() {
         '--sheen-blur': '22px',
         // Vitesse de balayage
         '--speed': '18s',
-      }}
+      } as WeaveVars}
     >
       {/* Couche 0 — Fond de base */}
       <div

--- a/components/ui/CakeBackground.tsx
+++ b/components/ui/CakeBackground.tsx
@@ -63,9 +63,9 @@ function makeTopoPath({
     return { x, y }
   })
   const d = [
-    `M ${pts[0].x} ${pts[0].y}`,
+    `M ${pts[0]!.x} ${pts[0]!.y}`,
     ...pts.slice(0, -1).map((p, i) => {
-      const p2 = pts[i + 1]
+      const p2 = pts[i + 1]!
       return `C ${p.x + c} ${p.y}, ${p2.x - c} ${p2.y}, ${p2.x} ${p2.y}`
     }),
   ].join(' ')

--- a/components/ui/CakeBackground.tsx
+++ b/components/ui/CakeBackground.tsx
@@ -52,11 +52,11 @@ function mulberry32(seed: number) {
 }
 
 function makeTopoPath({
-  W, H, baseY, amp, phase, freq,
-}: { W: number; H: number; baseY: number; amp: number; phase: number; freq: number; }) {
+  W, baseY, amp, phase, freq,
+}: { W: number; baseY: number; amp: number; phase: number; freq: number }) {
   const N = 12
   const k = (Math.PI * 2 * freq) / (N - 1)
-  const c = W / (N - 1) * 0.42
+  const c = (W / (N - 1)) * 0.42
   const pts = Array.from({ length: N }, (_, i) => {
     const x = (W / (N - 1)) * i
     const y = baseY + Math.sin(phase + i * k) * amp
@@ -72,6 +72,8 @@ function makeTopoPath({
   return d
 }
 
+const PHASES = [0, Math.PI / 2, Math.PI, (3 * Math.PI) / 2]
+
 /* =========================
    LIGNE TOPO : 1 <path> morphé
    ========================= */
@@ -86,10 +88,9 @@ function TopoLine({
   const amp = TOPO.ampBase + (rnd() - 0.5) * TOPO.ampJitter * 2
   const freq = clamp(TOPO.freq + (rnd() - 0.5) * 0.5, 1.6, 3.0)
 
-  const phases = [0, Math.PI / 2, Math.PI, (3 * Math.PI) / 2]
   const paths = useMemo(
-    () => phases.map(ph => makeTopoPath({ W, H, baseY, amp, phase: ph, freq })),
-    [W, H, baseY, amp, freq]
+    () => PHASES.map(ph => makeTopoPath({ W, baseY, amp, phase: ph, freq })),
+    [W, baseY, amp, freq]
   )
 
   const centerBias = 1 - Math.abs((index - (total - 1) / 2) / ((total - 1) / 2))
@@ -132,11 +133,11 @@ export default function CakeBackground() {
       {/* Halos très discrets */}
       <div
         className="absolute -top-[30vh] -left-[20vw] w-[90vw] h-[90vh] blur-3xl opacity-70"
-        style={{ background: `radial-gradient(50% 50% at 50% 50%, ${THEME.tintA} 0%, transparent 70%)`, mixBlendMode: 'screen' as any }}
+        style={{ background: `radial-gradient(50% 50% at 50% 50%, ${THEME.tintA} 0%, transparent 70%)`, mixBlendMode: 'screen' as React.CSSProperties['mixBlendMode'] }}
       />
       <div
         className="absolute -bottom-[35vh] -right-[25vw] w-[100vw] h-[100vh] blur-3xl opacity-70"
-        style={{ background: `radial-gradient(50% 50% at 50% 50%, ${THEME.tintB} 0%, transparent 70%)`, mixBlendMode: 'screen' as any }}
+        style={{ background: `radial-gradient(50% 50% at 50% 50%, ${THEME.tintB} 0%, transparent 70%)`, mixBlendMode: 'screen' as React.CSSProperties['mixBlendMode'] }}
       />
 
       {/* Lignes topo */}


### PR DESCRIPTION
## Summary
- tighten mixBlendMode typings in nebula and cake backgrounds
- replace CSS variable any casts in BananaBackground
- streamline topo helpers and typings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68976b69c6a4832ea08f9527708c085c