### PR TITLE
Restore collaborative summary editor

### DIFF
--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -38,7 +38,7 @@ export function Room({
           characters: new LiveMap(),
           images: new LiveMap(),
             music: new LiveObject({ id: '', playing: false, volume: 5 }),
-          summary: new LiveObject({ acts: [] }),
+          summary: new LiveObject({ acts: [], currentId: '' }),
           editor: new LiveMap(),
           events: new LiveList([]),
           rooms: new LiveList([])


### PR DESCRIPTION
## Summary
- Persist `currentId` in Liveblocks storage so reopening the panel restores the last opened page
- Re-enable Liveblocks Lexical editor with new InitialContentPlugin and light input/placeholder colors
- Keep text readable with white styling across summary controls

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6897c77531dc832e9abdc93033c10e23