### PR TITLE
fix: persist canvas drawings

### DIFF
--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -30,7 +30,8 @@ export function Room({
         initialStorage={{
           characters: new LiveMap(),
           images: new LiveMap(),
-            music: new LiveObject({ id: '', playing: false, volume: 5 }),
+          lines: new LiveList([]), // [FIX #5]
+          music: new LiveObject({ id: '', playing: false, volume: 5 }),
           summary: new LiveObject({ acts: [], currentId: '' }),
           editor: new LiveMap(),
           events: new LiveList([]),


### PR DESCRIPTION
## Summary
- keep room's drawn strokes in shared Liveblocks storage
- redraw stored strokes after mount/resize to avoid blank canvas on return
- clear stored strokes when clearing the canvas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898fb8bc638832eb0f45302572e6b1f