### PR TITLE
feat: make YouTube volume local per user

### DIFF
--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -30,7 +30,7 @@ export function Room({
         initialStorage={{
           characters: new LiveMap(),
           images: new LiveMap(),
-            music: new LiveObject({ id: '', playing: false, volume: 5 }),
+            music: new LiveObject({ id: '', playing: false }), // [FIX #6]
           summary: new LiveObject({ acts: [], currentId: '' }),
           editor: new LiveMap(),
           events: new LiveList([]),

--- a/components/rooms/RoomAvatarStack.tsx
+++ b/components/rooms/RoomAvatarStack.tsx
@@ -12,7 +12,7 @@ export default function RoomAvatarStack({ id }: { id: string }) {
         initialStorage={{
           characters: new LiveMap(),
           images: new LiveMap(),
-            music: new LiveObject({ id: '', playing: false, volume: 5 }),
+            music: new LiveObject({ id: '', playing: false }), // [FIX #6]
           summary: new LiveObject({ acts: [] }),
           editor: new LiveMap(),
           events: new LiveList([]),

--- a/liveblocks.config.ts
+++ b/liveblocks.config.ts
@@ -50,7 +50,7 @@ declare global {
     Storage: {
       characters: LiveMap<string, CharacterData>
       images: LiveMap<string, CanvasImage>
-        music: LiveObject<{ id: string; playing: boolean; volume: number }>
+        music: LiveObject<{ id: string; playing: boolean }> // [FIX #6]
       summary: LiveObject<{ acts: Array<{ id: string; title: string }> }>
       editor: LiveMap<string, string>
       events: LiveList<SessionEvent>


### PR DESCRIPTION
## Summary
- keep YouTube volume per user instead of shared globally
- store individual volume in localStorage and default to 5%
- remove volume field from Liveblocks storage

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6898fb9282e4832ebdf7a203d3807cdc