### PR TITLE
fix: keep character sheet selection local

### DIFF
--- a/components/misc/GMCharacterSelector.tsx
+++ b/components/misc/GMCharacterSelector.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState, useRef } from 'react'
-import { useBroadcastEvent, useOthers } from '@liveblocks/react'
+import { useOthers } from '@liveblocks/react'
 import { useT } from '@/lib/useT'
 import { User2 } from 'lucide-react'
 
@@ -21,7 +21,6 @@ export default function GMCharacterSelector({
   const [open, setOpen] = useState(false)
   const [selectedId, setSelectedId] = useState<string | number | null>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
-  const broadcast = useBroadcastEvent()
   const t = useT()
 
   // Récupère les personnages en temps réel via les presences
@@ -50,11 +49,8 @@ export default function GMCharacterSelector({
     if (!found) return
 
     setSelectedId(id)
+    // [FIX #7] Selection is local only; no event broadcast
     onSelect(found)
-    broadcast({
-      type: 'gm-select',
-      character: found,
-    })
     setOpen(false)
   }
 

--- a/liveblocks.config.ts
+++ b/liveblocks.config.ts
@@ -39,6 +39,8 @@ declare global {
     Presence: {
       // Currently selected character data
       character?: CharacterData
+      // [FIX #7] Local inspection indicator for MJ
+      inspecting?: string | number
       // Cursor position in canvas coordinates
       cursor?: { x: number; y: number } | null
       // Display name and color for cursors
@@ -81,7 +83,7 @@ declare global {
         }
       | { type: 'chat'; author: string; text: string; isMJ?: boolean }
       | { type: 'dice-roll'; player: string; dice: number; result: number }
-      | { type: 'gm-select'; character: CharacterData }
+      // [FIX #7] Removed gm-select event to keep sheet selection local
 
     // Custom metadata set on threads, for useThreads, useCreateThread, etc.
     ThreadMetadata: Record<string, never>


### PR DESCRIPTION
## Summary
- keep GM character inspection local to their client
- remove gm-select broadcasts and add optional presence indicator
- avoid overwriting players' active sheets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898fb99987c832e9e4ebe0d454b4d6d