### PR TITLE
Clamp canvas images within viewport

### DIFF
--- a/components/app/HomePageInner.tsx
+++ b/components/app/HomePageInner.tsx
@@ -167,7 +167,7 @@ export default function HomePageInner() {
   }
 
   return (
-    <div className="relative w-screen h-screen font-sans overflow-hidden bg-transparent">
+    <div className="relative w-screen h-dvh font-sans overflow-hidden bg-transparent">
       <div className="relative z-10 flex flex-col lg:flex-row w-full h-full">
         <CharacterSheet perso={perso} onUpdate={handleUpdatePerso} chatBoxRef={chatBoxRef} allCharacters={characters} logoOnly>
           {profile?.isMJ && (

--- a/components/canvas/ImageItem.tsx
+++ b/components/canvas/ImageItem.tsx
@@ -25,7 +25,7 @@ interface Props {
 
 const ImageItem: React.FC<Props> = ({ img, drawMode, onPointerDown, onDelete }) => (
   <div
-    className="absolute border border-white/20 rounded-2xl shadow-md group touch-none"
+    className="absolute border border-white/20 rounded-2xl shadow-md group touch-none transition-all duration-300"
     style={{ top: img.y, left: img.x, width: img.width, height: img.height, zIndex: 1 }}
   >
     {drawMode === 'images' && (

--- a/components/canvas/InteractiveCanvas.tsx
+++ b/components/canvas/InteractiveCanvas.tsx
@@ -87,6 +87,19 @@ export default function InteractiveCanvas() {
     })
   }, [])
 
+  const IMAGE_MIN_SIZE = 50
+
+  const clampImage = (img: ImageData, rect: DOMRect): ImageData => {
+    const width = Math.min(Math.max(img.width, IMAGE_MIN_SIZE), rect.width - img.x)
+    const height = Math.min(Math.max(img.height, IMAGE_MIN_SIZE), rect.height - img.y)
+    const x = Math.min(Math.max(img.x, 0), rect.width - width)
+    const y = Math.min(Math.max(img.y, 0), rect.height - height)
+    return { ...img, x, y, width, height }
+  }
+
+  const imagesRef = useRef<ImageData[]>([])
+  imagesRef.current = images
+
   // Mutation musique: gère l'état global (id, lecture, volume)
   const updateMusic = useMutation(
     (
@@ -159,6 +172,30 @@ export default function InteractiveCanvas() {
   }, [drawMode])
 
   useEffect(() => {
+    const handleResize = () => {
+      const rect = drawingCanvasRef.current?.getBoundingClientRect()
+      if (!rect) return
+      imagesRef.current.forEach((img) => {
+        const clamped = clampImage(img, rect)
+        if (
+          clamped.x !== img.x ||
+          clamped.y !== img.y ||
+          clamped.width !== img.width ||
+          clamped.height !== img.height
+        ) {
+          updateImage(clamped)
+        }
+      })
+    }
+    window.addEventListener('resize', handleResize)
+    window.addEventListener('orientationchange', handleResize)
+    return () => {
+      window.removeEventListener('resize', handleResize)
+      window.removeEventListener('orientationchange', handleResize)
+    }
+  }, [updateImage])
+
+  useEffect(() => {
     if (drawMode === 'erase') {
       setEraserSize((s) => Math.min(Math.max(s, ERASE_MIN), ERASE_MAX))
     } else {
@@ -199,6 +236,7 @@ export default function InteractiveCanvas() {
     file: File,
     dropX: number,
     dropY: number,
+    rect: DOMRect,
   ) {
     const localUrl = fileToObjectURL(file)
     const tempId = Date.now() + Math.random()
@@ -210,7 +248,8 @@ export default function InteractiveCanvas() {
       width: 200,
       height: 200,
     }
-    addImage(tempImg)
+    const clamped = clampImage(tempImg, rect)
+    addImage(clamped)
 
     try {
       const form = new FormData()
@@ -229,7 +268,7 @@ export default function InteractiveCanvas() {
         throw new Error('No URL returned by Cloudinary endpoint')
       }
 
-      updateImage({ ...tempImg, src: finalUrl })
+      updateImage({ ...clamped, src: finalUrl })
     } catch (err) {
       deleteImage(tempId)
       console.error(err)
@@ -250,6 +289,7 @@ export default function InteractiveCanvas() {
         file,
         e.clientX - rect.left,
         e.clientY - rect.top,
+        rect,
       )
     }
   }
@@ -336,17 +376,9 @@ export default function InteractiveCanvas() {
     if (!img) return
     const updated =
       type === 'move'
-        ? {
-            ...img,
-            x: Math.max(0, Math.min(x - offsetX, rect.width - img.width)),
-            y: Math.max(0, Math.min(y - offsetY, rect.height - img.height)),
-          }
-        : {
-            ...img,
-            width: Math.max(50, x - img.x),
-            height: Math.max(50, y - img.y),
-          }
-    updateImage(updated)
+        ? { ...img, x: x - offsetX, y: y - offsetY }
+        : { ...img, width: x - img.x, height: y - img.y }
+    updateImage(clampImage(updated, rect))
   }
 
   const handlePointerUp = () => {
@@ -361,16 +393,18 @@ export default function InteractiveCanvas() {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (drawMode !== 'images' || selectedImageId === null) return
     const img = images.find((i) => i.id === selectedImageId)
-    if (!img) return
+    const rect = drawingCanvasRef.current?.getBoundingClientRect()
+    if (!img || !rect) return
     const step = 5
-    const updates: Partial<ImageData> = {}
-    if (e.key === 'ArrowUp') updates.y = Math.max(0, img.y - step)
-    else if (e.key === 'ArrowDown') updates.y = img.y + step
-    else if (e.key === 'ArrowLeft') updates.x = Math.max(0, img.x - step)
-    else if (e.key === 'ArrowRight') updates.x = img.x + step
-    if (Object.keys(updates).length) {
+    let updated = { ...img }
+    if (e.key === 'ArrowUp') updated.y -= step
+    else if (e.key === 'ArrowDown') updated.y += step
+    else if (e.key === 'ArrowLeft') updated.x -= step
+    else if (e.key === 'ArrowRight') updated.x += step
+    updated = clampImage(updated, rect)
+    if (updated.x !== img.x || updated.y !== img.y) {
       e.preventDefault()
-      updateImage({ ...img, ...updates })
+      updateImage(updated)
     }
   }
 


### PR DESCRIPTION
## Summary
- Clamp image placement and scaling to canvas bounds before syncing to Liveblocks
- Reposition images on resize/orientation change with smooth transitions
- Use dynamic viewport height for full-screen canvas on tablets

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b41e239f40832eb00d1f637082b363