### PR TITLE
feat: use server timestamp for dice messages

### DIFF
--- a/app/api/timestamp/route.ts
+++ b/app/api/timestamp/route.ts
@@ -1,0 +1,13 @@
+export const runtime = 'nodejs';
+
+let last = 0;
+
+export async function GET() {
+  const now = Date.now();
+  if (now <= last) {
+    last += 1;
+  } else {
+    last = now;
+  }
+  return Response.json({ ts: last });
+}

--- a/components/app/HomePageInner.tsx
+++ b/components/app/HomePageInner.tsx
@@ -46,7 +46,7 @@ export default function HomePageInner() {
   useEventListener((payload: any) => {
     const { event } = payload
     if (event.type === 'dice-roll') {
-      setHistory((h) => [...h, { player: event.player, dice: event.dice, result: event.result, ts: Date.now() }])
+      setHistory((h) => [...h, { player: event.player, dice: event.dice, result: event.result, ts: event.ts ?? Date.now() }])
     } else if (event.type === 'gm-select') {
       const char = event.character || defaultPerso
       if (!char.id) char.id = crypto.randomUUID()
@@ -150,11 +150,19 @@ export default function HomePageInner() {
   const handlePopupReveal = () => {
     if (!pendingRoll) return
     const { nom, dice, result } = pendingRoll
-    const entry = { player: nom, dice, result, ts: Date.now() }
-    setHistory((h) => [...h, entry])
-    broadcast({ type: 'dice-roll', player: nom, dice, result } as Liveblocks['RoomEvent'])
-    addEvent({ id: crypto.randomUUID(), kind: 'dice', player: nom, dice, result, ts: entry.ts })
-    setPendingRoll(null)
+    ;(async () => {
+      let ts = Date.now()
+      try {
+        const res = await fetch('/api/timestamp')
+        const data = await res.json()
+        if (typeof data.ts === 'number') ts = data.ts
+      } catch {}
+      const entry = { player: nom, dice, result, ts }
+      setHistory((h) => [...h, entry])
+      broadcast({ type: 'dice-roll', player: nom, dice, result, ts } as Liveblocks['RoomEvent'])
+      addEvent({ id: crypto.randomUUID(), kind: 'dice', player: nom, dice, result, ts })
+      setPendingRoll(null)
+    })()
   }
 
   const handlePopupFinish = () => {

--- a/components/chat/ChatBox.tsx
+++ b/components/chat/ChatBox.tsx
@@ -43,13 +43,19 @@ const ChatBox: FC<Props> = ({ chatBoxRef, history, author }) => {
   }, [collapsed])
 
 
-  const sendMessage = () => {
+  const sendMessage = async () => {
     if (inputValue.trim() === '') return
 
     const msg = { author, text: inputValue.trim(), isMJ: profile?.isMJ }
+    let ts = Date.now()
+    try {
+      const res = await fetch('/api/timestamp')
+      const data = await res.json()
+      if (typeof data.ts === 'number') ts = data.ts
+    } catch {}
 
     broadcast({ type: 'chat', author: msg.author, text: msg.text, isMJ: msg.isMJ } as Liveblocks['RoomEvent'])
-    addEvent({ id: crypto.randomUUID(), kind: 'chat', author: msg.author, text: msg.text, ts: Date.now(), isMJ: msg.isMJ })
+    addEvent({ id: crypto.randomUUID(), kind: 'chat', author: msg.author, text: msg.text, ts, isMJ: msg.isMJ })
     setInputValue('')
   }
 

--- a/liveblocks.config.ts
+++ b/liveblocks.config.ts
@@ -79,8 +79,8 @@ declare global {
           width: number
           mode: 'draw' | 'erase'
         }
-      | { type: 'chat'; author: string; text: string; isMJ?: boolean }
-      | { type: 'dice-roll'; player: string; dice: number; result: number }
+      | { type: 'chat'; author: string; text: string; isMJ?: boolean; ts?: number }
+      | { type: 'dice-roll'; player: string; dice: number; result: number; ts: number }
       | { type: 'gm-select'; character: CharacterData }
 
     // Custom metadata set on threads, for useThreads, useCreateThread, etc.


### PR DESCRIPTION
## Summary
- add API route returning unique server timestamps
- use server timestamps for dice rolls and chat messages
- include timestamp in dice roll live events

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b41e296240832eb629da6bcc9ffff8