### PR TITLE
feat: sync side notes offline

### DIFF
--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -32,6 +32,7 @@ export function Room({
           images: new LiveMap(),
             music: new LiveObject({ id: '', playing: false, volume: 5 }),
           summary: new LiveObject({ acts: [], currentId: '' }),
+          quickNote: new LiveObject({ text: '', updatedAt: 0 }),
           editor: new LiveMap(),
           events: new LiveList([]),
           rooms: new LiveList([])

--- a/components/misc/SideNotes.tsx
+++ b/components/misc/SideNotes.tsx
@@ -1,36 +1,117 @@
 'use client'
 import { useState, useEffect, useRef } from 'react'
+import { useStorage, useMutation, useStatus } from '@liveblocks/react'
+import { LiveObject } from '@liveblocks/client'
 import { useT } from '@/lib/useT'
 
-const STORAGE_KEY = 'jdr_side_notes'
-const HEIGHT_KEY = 'jdr_side_notes_height'
+const LIVE_KEY = 'quickNote' as const
+const LOCAL_KEY = 'codex_quicknote'
+const HEIGHT_KEY = 'codex_quicknote_height'
+
+type NoteData = { text: string; updatedAt: number }
+
+function loadLocal(): NoteData {
+  try {
+    const raw = localStorage.getItem(LOCAL_KEY)
+    if (!raw) return { text: '', updatedAt: 0 }
+    const parsed = JSON.parse(raw)
+    return {
+      text: typeof parsed.text === 'string' ? parsed.text : '',
+      updatedAt: typeof parsed.updatedAt === 'number' ? parsed.updatedAt : 0,
+    }
+  } catch {
+    return { text: '', updatedAt: 0 }
+  }
+}
+
+function saveLocal(data: NoteData) {
+  try {
+    localStorage.setItem(LOCAL_KEY, JSON.stringify(data))
+  } catch {}
+}
 
 export default function SideNotes() {
   const [open, setOpen] = useState(false)
   const [notes, setNotes] = useState('')
-  const [height, setHeight] = useState<number>(192) // 48*4 = 192px par défaut
+  const [height, setHeight] = useState<number>(192)
+  const [updated, setUpdated] = useState(0)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const t = useT()
 
-  // Charger les notes et la hauteur au démarrage
+  const status = useStatus() as string
+  const liveObj = useStorage(root => root.quickNote) as LiveObject<NoteData> | undefined
+
+  const updateLive = useMutation(({ storage }, data: NoteData) => {
+    const obj = storage.get(LIVE_KEY)
+    if (obj instanceof LiveObject) obj.update(data)
+    else storage.set(LIVE_KEY, new LiveObject(data))
+  }, [])
+
+  // Initial load
   useEffect(() => {
-    const saved = localStorage.getItem(STORAGE_KEY)
-    if (saved) setNotes(saved)
+    const local = loadLocal()
+    setNotes(local.text)
+    setUpdated(local.updatedAt)
     const savedHeight = localStorage.getItem(HEIGHT_KEY)
     if (savedHeight) setHeight(Number(savedHeight))
   }, [])
 
-  // Sauver les notes à chaque modif
+  // Connection guard & resync
   useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, notes)
-  }, [notes])
+    if (status === 'connected') {
+      const remote = liveObj ? liveObj.toObject() : { text: '', updatedAt: 0 }
+      const local = loadLocal()
+      if (local.updatedAt > remote.updatedAt) {
+        updateLive(local)
+        setNotes(local.text)
+        setUpdated(local.updatedAt)
+      } else {
+        setNotes(remote.text)
+        setUpdated(remote.updatedAt)
+        saveLocal(remote)
+      }
+    } else if (status === 'disconnected') {
+      const local = loadLocal()
+      setNotes(local.text)
+      setUpdated(local.updatedAt)
+    } else {
+      const id = setTimeout(() => {
+        if (status !== 'connected') {
+          const local = loadLocal()
+          setNotes(local.text)
+          setUpdated(local.updatedAt)
+        }
+      }, 3000)
+      return () => clearTimeout(id)
+    }
+  }, [status, liveObj, updateLive])
 
-  // Sauver la hauteur à chaque modif
+  // Sync remote changes to local
+  useEffect(() => {
+    if (status === 'connected' && liveObj) {
+      const { text, updatedAt } = liveObj.toObject()
+      setNotes(text)
+      setUpdated(updatedAt)
+      saveLocal({ text, updatedAt })
+    }
+  }, [liveObj, status])
+
+  // Save height
   useEffect(() => {
     localStorage.setItem(HEIGHT_KEY, String(height))
   }, [height])
 
-  // Gérer la détection de resize (on le fait à la fermeture OU quand on perd le focus)
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const val = e.target.value
+    const ts = Date.now()
+    setNotes(val)
+    setUpdated(ts)
+    saveLocal({ text: val, updatedAt: ts })
+    if (status === 'connected') {
+      updateLive({ text: val, updatedAt: ts })
+    }
+  }
+
   const handleResize = () => {
     if (textareaRef.current) {
       setHeight(textareaRef.current.offsetHeight)
@@ -38,87 +119,59 @@ export default function SideNotes() {
   }
 
   return (
-    <div
-      className="absolute bottom-4 left-4 z-50"
-    >
+    <div className="absolute bottom-4 left-4 z-50">
       {open ? (
-        <div
-          className="
-            relative rounded-2xl border border-white/10
-            bg-black/30 backdrop-blur-[2.5px] shadow-2xl shadow-black/15
-            text-white p-3 w-72 transition-all
-          "
-        >
+        <div className="relative rounded-2xl border border-white/10 bg-black/30 backdrop-blur-[2.5px] shadow-2xl shadow-black/15 text-white p-3 w-72 transition-all">
           <textarea
             ref={textareaRef}
             className="w-full bg-black/20 rounded-xl p-2 text-sm resize-y border border-white/10 focus:ring-2 focus:ring-blue-500/20 transition"
             style={{ height }}
             value={notes}
-            onChange={e => setNotes(e.target.value)}
+            onChange={handleChange}
             onBlur={handleResize}
             onMouseUp={handleResize}
           />
           <div className="flex justify-between items-center mt-2">
             <button
               className="bg-emerald-600/90 hover:bg-emerald-500/90 text-white px-3 py-1 rounded-md text-xs shadow transition"
-              onClick={() => localStorage.setItem(STORAGE_KEY, notes)}
-            >{t('save')}</button>
+              onClick={() => saveLocal({ text: notes, updatedAt: updated })}
+            >
+              {t('save')}
+            </button>
             <button
-              className="
-                absolute -right-4 top-1/2 -translate-y-1/2
-                bg-black/60 hover:bg-black/90 text-white border border-white/15
-                rounded-xl shadow
-                flex items-center justify-center
-                transition
-              "
+              className="absolute -right-4 top-1/2 -translate-y-1/2 bg-black/60 hover:bg-black/90 text-white border border-white/15 rounded-xl shadow flex items-center justify-center transition"
               onClick={() => {
                 handleResize()
                 setOpen(false)
               }}
               title={t('close')}
-              style={{
-                fontSize: '1.1rem',
-                width: 32,
-                height: 32,
-                padding: 0,
-              }}
+              style={{ fontSize: '1.1rem', width: 32, height: 32, padding: 0 }}
             >
-              <span style={{ fontWeight: 700, fontSize: "1.35em", lineHeight: "1" }}>×</span>
+              <span style={{ fontWeight: 700, fontSize: '1.35em', lineHeight: '1' }}>×</span>
             </button>
           </div>
         </div>
       ) : (
         <button
-  className="
-    bg-black/25 hover:bg-black/50 border border-white/10
-    rounded-xl shadow-lg backdrop-blur-[2.5px]
-    flex items-center justify-center transition
-  "
-  onClick={() => setOpen(true)}
-  title={t('notes')}
-  style={{
-    width: 40,
-    height: 40,
-    fontSize: '1.2rem',
-    padding: 0,
-  }}
->
-  {/* Icône note/papier minimaliste, SVG inline */}
-  <svg
-    width="22"
-    height="22"
-    viewBox="0 0 22 22"
-    fill="none"
-    aria-hidden="true"
-    className="opacity-80"
-  >
-    <rect x="4" y="3.5" width="14" height="15" rx="3.5" stroke="white" strokeWidth="1.3" fill="none"/>
-    <line x1="7" y1="7.7" x2="15" y2="7.7" stroke="white" strokeWidth="1.1" strokeLinecap="round"/>
-    <line x1="7" y1="11" x2="15" y2="11" stroke="white" strokeWidth="1.1" strokeLinecap="round"/>
-    <line x1="7" y1="14.3" x2="13" y2="14.3" stroke="white" strokeWidth="1.1" strokeLinecap="round"/>
-  </svg>
-</button>
-
+          className="bg-black/25 hover:bg-black/50 border border-white/10 rounded-xl shadow-lg backdrop-blur-[2.5px] flex items-center justify-center transition"
+          onClick={() => setOpen(true)}
+          title={t('notes')}
+          style={{ width: 40, height: 40, fontSize: '1.2rem', padding: 0 }}
+        >
+          <svg
+            width="22"
+            height="22"
+            viewBox="0 0 22 22"
+            fill="none"
+            aria-hidden="true"
+            className="opacity-80"
+          >
+            <rect x="4" y="3.5" width="14" height="15" rx="3.5" stroke="white" strokeWidth="1.3" fill="none"/>
+            <line x1="7" y1="7.7" x2="15" y2="7.7" stroke="white" strokeWidth="1.1" strokeLinecap="round"/>
+            <line x1="7" y1="11" x2="15" y2="11" stroke="white" strokeWidth="1.1" strokeLinecap="round"/>
+            <line x1="7" y1="14.3" x2="13" y2="14.3" stroke="white" strokeWidth="1.1" strokeLinecap="round"/>
+          </svg>
+        </button>
       )}
     </div>
   )

--- a/liveblocks.config.ts
+++ b/liveblocks.config.ts
@@ -52,6 +52,7 @@ declare global {
       images: LiveMap<string, CanvasImage>
         music: LiveObject<{ id: string; playing: boolean; volume: number }>
       summary: LiveObject<{ acts: Array<{ id: string; title: string }> }>
+      quickNote: LiveObject<{ text: string; updatedAt: number }>
       editor: LiveMap<string, string>
       events: LiveList<SessionEvent>
       rooms: LiveList<Room>


### PR DESCRIPTION
## Summary
- add quickNote storage type for Liveblocks
- sync SideNotes with Liveblocks and localStorage for offline resilience

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b41e354c5c832eb1719cf58628be3f