### PR TITLE
fix: preserve canvas when leaving room

### DIFF
--- a/components/rooms/RoomAvatarStack.tsx
+++ b/components/rooms/RoomAvatarStack.tsx
@@ -1,24 +1,11 @@
 'use client'
 import { LiveblocksProvider, RoomProvider, ClientSideSuspense } from '@liveblocks/react/suspense'
-import { LiveMap, LiveObject, LiveList } from '@liveblocks/client'
 import LiveAvatarStack from '../chat/LiveAvatarStack'
 
 export default function RoomAvatarStack({ id }: { id: string }) {
   return (
     <LiveblocksProvider authEndpoint="/api/liveblocks-auth">
-      <RoomProvider
-        id={id}
-        initialPresence={{}}
-        initialStorage={{
-          characters: new LiveMap(),
-          images: new LiveMap(),
-            music: new LiveObject({ id: '', playing: false, volume: 5 }),
-          summary: new LiveObject({ acts: [] }),
-          editor: new LiveMap(),
-          events: new LiveList([]),
-          rooms: new LiveList([])
-        }}
-      >
+      <RoomProvider id={id} initialPresence={{}}>
         <ClientSideSuspense fallback={null}>
           <LiveAvatarStack className="absolute right-2 top-1/2 -translate-y-1/2 flex flex-row-reverse gap-1" size={20} />
         </ClientSideSuspense>


### PR DESCRIPTION
## Summary
- prevent room list from wiping Liveblocks storage by removing initialStorage from RoomAvatarStack
- lazily initialize room storage to keep existing drawings when re-entering a room

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b41e3aed14832ea0442768cd84d3df