### PR TITLE
style: improve input placeholder contrast

### DIFF
--- a/components/character/AddCompetenceModal.tsx
+++ b/components/character/AddCompetenceModal.tsx
@@ -69,7 +69,7 @@ export const AddCompetenceModal: React.FC<AddCompetenceModalProps> = ({
                     <div>
                         <label className="block text-sm mb-1">{t('name')}</label>
                         <input
-                            className="w-full px-2 py-1 rounded bg-gray-800 text-white"
+                            className="w-full px-2 py-1 rounded bg-gray-800 text-white placeholder-white"
                             value={nom}
                             onChange={e => setNom(e.target.value)}
                             placeholder={t('skillName')}
@@ -90,7 +90,7 @@ export const AddCompetenceModal: React.FC<AddCompetenceModalProps> = ({
                     <div>
                         <label className="block text-sm mb-1">{t('effects')}</label>
                         <input
-                            className="w-full px-2 py-1 rounded bg-gray-800 text-white"
+                            className="w-full px-2 py-1 rounded bg-gray-800 text-white placeholder-white"
                             value={effets}
                             onChange={e => setEffets(e.target.value)}
                             placeholder={t('effectDesc')}
@@ -99,7 +99,7 @@ export const AddCompetenceModal: React.FC<AddCompetenceModalProps> = ({
                     <div>
                         <label className="block text-sm mb-1">{t('damageOptional')}</label>
                         <input
-                            className="w-full px-2 py-1 rounded bg-gray-800 text-white"
+                            className="w-full px-2 py-1 rounded bg-gray-800 text-white placeholder-white"
                             value={degats}
                             onChange={e => setDegats(e.target.value)}
                             placeholder="Ex: 2d6+3"

--- a/components/login/Login.tsx
+++ b/components/login/Login.tsx
@@ -268,7 +268,7 @@ export default function Login({ onLogin }: { onLogin: (p: string) => void }) {
                     value={pseudo}
                     onChange={(e) => setPseudo(e.target.value)}
                     placeholder={t('username')}
-                    className="px-2 py-1 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-pink-400"
+                    className="px-2 py-1 rounded bg-gray-700 text-white placeholder-white focus:outline-none focus:ring-2 focus:ring-pink-400"
                     style={{
                       width: CUBE_SIZE * 0.6,
                       textAlign: 'center',

--- a/components/rooms/RoomCreateModal.tsx
+++ b/components/rooms/RoomCreateModal.tsx
@@ -60,7 +60,7 @@ export default function RoomCreateModal({ open, onClose, onCreated }: Props) {
       <div onClick={e => e.stopPropagation()} className="bg-black/80 text-white rounded-2xl border border-white/10 shadow-2xl backdrop-blur-md p-5 w-80">
         <h2 className="text-lg font-semibold mb-2">{t('createRoom')}</h2>
         <input
-          className="w-full mb-2 px-2 py-1 rounded bg-gray-800 text-white border border-white/20 focus:outline-none focus:ring-2 focus:ring-pink-400/30"
+          className="w-full mb-2 px-2 py-1 rounded bg-gray-800 text-white placeholder-white border border-white/20 focus:outline-none focus:ring-2 focus:ring-pink-400/30"
           placeholder={t('name')}
           value={name}
           onChange={e => setName(e.target.value)}
@@ -77,7 +77,7 @@ export default function RoomCreateModal({ open, onClose, onCreated }: Props) {
         {withPassword && (
           <input
             type="password"
-            className="w-full mb-2 px-2 py-1 rounded bg-gray-800 text-white border border-white/20 focus:outline-none focus:ring-2 focus:ring-pink-400/30"
+            className="w-full mb-2 px-2 py-1 rounded bg-gray-800 text-white placeholder-white border border-white/20 focus:outline-none focus:ring-2 focus:ring-pink-400/30"
             placeholder={t('password')}
             value={password}
             onChange={e => setPassword(e.target.value)}


### PR DESCRIPTION
## Summary
- ensure dark theme inputs show white placeholders and text for readability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b41e5fee78832e98ddefa011bd1702