### PR TITLE
Persist canvas strokes

### DIFF
--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -34,7 +34,8 @@ export function Room({
           summary: new LiveObject({ acts: [], currentId: '' }),
           editor: new LiveMap(),
           events: new LiveList([]),
-          rooms: new LiveList([])
+          rooms: new LiveList([]),
+          strokes: new LiveList([])
         }}
       >
         <ClientSideSuspense fallback={<div>Loading…</div>}>

--- a/components/canvas/InteractiveCanvas.tsx
+++ b/components/canvas/InteractiveCanvas.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef, useState, useEffect } from 'react'
+import { useRef, useState, useEffect, useCallback } from 'react'
 import {
   useBroadcastEvent,
   useEventListener,
@@ -16,6 +16,7 @@ import { useT } from '@/lib/useT'
 import MusicPanel from './MusicPanel'
 import ImageItem, { ImageData } from './ImageItem'
 import SideNotes from '@/components/misc/SideNotes'
+import type { Stroke } from '@/liveblocks.config'
 
 export default function InteractiveCanvas() {
   // `images` map is created by RoomProvider but may be null until ready
@@ -26,6 +27,7 @@ export default function InteractiveCanvas() {
 
   const musicObj = useStorage((root) => root.music) // peut être null au démarrage
   const storageReady = Boolean(musicObj)
+  const strokesList = useStorage((root) => root.strokes)
 
   const [isDrawing, setIsDrawing] = useState(false)
   const [drawMode, setDrawMode] = useState<ToolMode>('images')
@@ -87,6 +89,41 @@ export default function InteractiveCanvas() {
     })
   }, [])
 
+  const appendStroke = useMutation(({ storage }, stroke: Stroke) => {
+    storage.get('strokes').push(stroke)
+  }, [])
+
+  const clearStrokes = useMutation(({ storage }) => {
+    storage.get('strokes').clear()
+  }, [])
+
+  const drawStroke = useCallback(
+    ({ x1, y1, x2, y2, color: c, width, mode }: Stroke) => {
+      if (!ctxRef.current) return
+      ctxRef.current.strokeStyle = mode === 'erase' ? 'rgba(0,0,0,1)' : c
+      ctxRef.current.lineWidth = width
+      ctxRef.current.globalCompositeOperation =
+        mode === 'erase' ? 'destination-out' : 'source-over'
+      ctxRef.current.beginPath()
+      ctxRef.current.moveTo(x1, y1)
+      ctxRef.current.lineTo(x2, y2)
+      ctxRef.current.stroke()
+    },
+    [],
+  )
+
+  const rebuildCanvas = useCallback(() => {
+    const ctx = ctxRef.current
+    const canvas = drawingCanvasRef.current
+    if (!ctx || !canvas) return
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    strokesList?.forEach(drawStroke)
+  }, [strokesList, drawStroke])
+
+  useEffect(() => {
+    rebuildCanvas()
+  }, [rebuildCanvas])
+
   // Mutation musique: gère l'état global (id, lecture, volume)
   const updateMusic = useMutation(
     (
@@ -103,17 +140,9 @@ export default function InteractiveCanvas() {
   useEventListener((payload: any) => {
     const { event } = payload
     if (event.type === 'clear-canvas') {
-      clearCanvas(false)
-    } else if (event.type === 'draw-line' && ctxRef.current) {
-      const { x1, y1, x2, y2, color: c, width, mode } = event
-      ctxRef.current.strokeStyle = mode === 'erase' ? 'rgba(0,0,0,1)' : c
-      ctxRef.current.lineWidth = width
-      ctxRef.current.globalCompositeOperation =
-        mode === 'erase' ? 'destination-out' : 'source-over'
-      ctxRef.current.beginPath()
-      ctxRef.current.moveTo(x1, y1)
-      ctxRef.current.lineTo(x2, y2)
-      ctxRef.current.stroke()
+      clearCanvas(false, false)
+    } else if (event.type === 'draw-line') {
+      drawStroke(event)
     }
   })
 
@@ -143,13 +172,14 @@ export default function InteractiveCanvas() {
             ctx.lineCap = 'round'
             ctx.lineJoin = 'round'
             ctxRef.current = ctx
+            rebuildCanvas()
           }
         }
       }
       resize()
       window.addEventListener('resize', resize)
       return () => window.removeEventListener('resize', resize)
-    }, [toolsVisible, audioVisible])
+    }, [toolsVisible, audioVisible, rebuildCanvas])
 
   useEffect(() => {
     const canvas = drawingCanvasRef.current
@@ -317,8 +347,8 @@ export default function InteractiveCanvas() {
       const now = Date.now()
       if (THROTTLE === 0 || now - lastSend.current > THROTTLE) {
         lastSend.current = now
-        broadcast({
-          type: 'draw-line',
+        const stroke: Stroke = {
+          id: crypto.randomUUID(),
           x1: px,
           y1: py,
           x2: x,
@@ -326,7 +356,9 @@ export default function InteractiveCanvas() {
           color,
           width: brushSize,
           mode: drawMode,
-        } as Liveblocks['RoomEvent'])
+        }
+        broadcast({ type: 'draw-line', ...stroke } as Liveblocks['RoomEvent'])
+        appendStroke(stroke)
       }
     }
 
@@ -374,8 +406,11 @@ export default function InteractiveCanvas() {
     }
   }
 
-  const clearCanvas = (broadcastChange = true) => {
+  const clearCanvas = (broadcastChange = true, updateStorage = true) => {
     clearImages()
+    if (updateStorage) {
+      clearStrokes()
+    }
     const ctx = ctxRef.current
     if (ctx && drawingCanvasRef.current) {
       ctx.clearRect(

--- a/components/rooms/RoomAvatarStack.tsx
+++ b/components/rooms/RoomAvatarStack.tsx
@@ -16,7 +16,8 @@ export default function RoomAvatarStack({ id }: { id: string }) {
           summary: new LiveObject({ acts: [] }),
           editor: new LiveMap(),
           events: new LiveList([]),
-          rooms: new LiveList([])
+          rooms: new LiveList([]),
+          strokes: new LiveList([])
         }}
       >
         <ClientSideSuspense fallback={null}>

--- a/liveblocks.config.ts
+++ b/liveblocks.config.ts
@@ -31,6 +31,17 @@ type Room = {
   owner?: string | null
 }
 
+type Stroke = {
+  id: string
+  x1: number
+  y1: number
+  x2: number
+  y2: number
+  color: string
+  width: number
+  mode: 'draw' | 'erase'
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type CharacterData = any
 declare global {
@@ -55,6 +66,7 @@ declare global {
       editor: LiveMap<string, string>
       events: LiveList<SessionEvent>
       rooms: LiveList<Room>
+      strokes: LiveList<Stroke>
     }
 
     // Custom user info set when authenticating with a secret key
@@ -71,6 +83,7 @@ declare global {
       | { type: 'clear-canvas' }
       | {
           type: 'draw-line'
+          id: string
           x1: number
           y1: number
           x2: number
@@ -91,4 +104,4 @@ declare global {
   }
 }
 
-export {}
+export type { Stroke }

--- a/package.json
+++ b/package.json
@@ -7,10 +7,8 @@
     "build": "next build",
     "build:analyze": "ANALYZE=true next build",
     "start": "next start",
-
     "type-check": "tsc --noEmit",
     "lint": "next lint",
-
     "test": "npm run lint"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- store canvas strokes in Liveblocks storage with UUIDs and incremental updates
- rebuild canvas from stored strokes on resize or reconnection
- add stroke list to room initialization
- iterate through stored strokes without converting to array
- generate stroke IDs with `crypto.randomUUID()` and remove external `uuid` dependency

## Testing
- `npm test`
- `npm run build` *(fails: Missing Liveblocks API key)*

------
https://chatgpt.com/codex/tasks/task_e_68b41e53df1c832e9664b0d48402ffe2