### PR TITLE
feat: store music volume locally

### DIFF
--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -30,7 +30,7 @@ export function Room({
         initialStorage={{
           characters: new LiveMap(),
           images: new LiveMap(),
-            music: new LiveObject({ id: '', playing: false, volume: 5 }),
+          music: new LiveObject({ id: '', playing: false }),
           summary: new LiveObject({ acts: [], currentId: '' }),
           editor: new LiveMap(),
           events: new LiveList([]),

--- a/components/rooms/RoomAvatarStack.tsx
+++ b/components/rooms/RoomAvatarStack.tsx
@@ -12,7 +12,7 @@ export default function RoomAvatarStack({ id }: { id: string }) {
         initialStorage={{
           characters: new LiveMap(),
           images: new LiveMap(),
-            music: new LiveObject({ id: '', playing: false, volume: 5 }),
+            music: new LiveObject({ id: '', playing: false }),
           summary: new LiveObject({ acts: [] }),
           editor: new LiveMap(),
           events: new LiveList([]),

--- a/liveblocks.config.ts
+++ b/liveblocks.config.ts
@@ -50,8 +50,8 @@ declare global {
     Storage: {
       characters: LiveMap<string, CharacterData>
       images: LiveMap<string, CanvasImage>
-        music: LiveObject<{ id: string; playing: boolean; volume: number }>
-      summary: LiveObject<{ acts: Array<{ id: string; title: string }> }>
+      music: LiveObject<{ id: string; playing: boolean }>
+      summary: LiveObject<{ acts: Array<{ id: string; title: string }>; currentId?: string }>
       editor: LiveMap<string, string>
       events: LiveList<SessionEvent>
       rooms: LiveList<Room>


### PR DESCRIPTION
## Summary
- persist music volume per user using localStorage
- drop volume and quickNote from Liveblocks state and align summary typing
- clamp images to canvas on resize without undefined ref

## Testing
- `npm test`
- `npm run build` *(fails: Invalid value for field 'secret')*


------
https://chatgpt.com/codex/tasks/task_e_68b41e401e60832e892592d162054345