### PR TITLE
Persist canvas strokes

### DIFF
--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -34,7 +34,8 @@ export function Room({
           summary: new LiveObject({ acts: [], currentId: '' }),
           editor: new LiveMap(),
           events: new LiveList([]),
-          rooms: new LiveList([])
+          rooms: new LiveList([]),
+          strokes: new LiveList([])
         }}
       >
         <ClientSideSuspense fallback={<div>Loading…</div>}>

--- a/components/rooms/RoomAvatarStack.tsx
+++ b/components/rooms/RoomAvatarStack.tsx
@@ -16,7 +16,8 @@ export default function RoomAvatarStack({ id }: { id: string }) {
           summary: new LiveObject({ acts: [] }),
           editor: new LiveMap(),
           events: new LiveList([]),
-          rooms: new LiveList([])
+          rooms: new LiveList([]),
+          strokes: new LiveList([])
         }}
       >
         <ClientSideSuspense fallback={null}>

--- a/liveblocks.config.ts
+++ b/liveblocks.config.ts
@@ -31,6 +31,17 @@ type Room = {
   owner?: string | null
 }
 
+type Stroke = {
+  id: string
+  x1: number
+  y1: number
+  x2: number
+  y2: number
+  color: string
+  width: number
+  mode: 'draw' | 'erase'
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type CharacterData = any
 declare global {
@@ -55,6 +66,7 @@ declare global {
       editor: LiveMap<string, string>
       events: LiveList<SessionEvent>
       rooms: LiveList<Room>
+      strokes: LiveList<Stroke>
     }
 
     // Custom user info set when authenticating with a secret key
@@ -71,6 +83,7 @@ declare global {
       | { type: 'clear-canvas' }
       | {
           type: 'draw-line'
+          id: string
           x1: number
           y1: number
           x2: number
@@ -91,4 +104,4 @@ declare global {
   }
 }
 
-export {}
+export type { Stroke }

--- a/package.json
+++ b/package.json
@@ -7,10 +7,8 @@
     "build": "next build",
     "build:analyze": "ANALYZE=true next build",
     "start": "next start",
-
     "type-check": "tsc --noEmit",
     "lint": "next lint",
-
     "test": "npm run lint"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- store canvas strokes in Liveblocks storage with UUIDs and incremental updates
- rebuild canvas from stored strokes on resize or reconnection
- add stroke list to room initialization
- iterate through stored strokes without converting to array
- generate stroke IDs with `crypto.randomUUID()` and remove external `uuid` dependency
- clamp image positions to canvas bounds using current array instead of stale ref

## Testing
- `npm test`
- `npm run build` *(fails: Invalid value for field 'secret' for Liveblocks API key)*

------
https://chatgpt.com/codex/tasks/task_e_68b41e53df1c832e9664b0d48402ffe2