### PR TITLE
fix: use LiveList for session summary acts

### DIFF
--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -32,7 +32,7 @@ export function Room({
           images: new LiveMap(),
             music: new LiveObject({ id: '', playing: false, volume: 5 }),
 
-          summary: new LiveObject({ acts: [], currentId: '' }),
+          summary: new LiveObject({ acts: new LiveList<{ id: string; title: string }>([]), currentId: '' }),
           quickNote: new LiveObject({ text: '', updatedAt: 0 }),
 
           editor: new LiveMap(),

--- a/components/rooms/RoomAvatarStack.tsx
+++ b/components/rooms/RoomAvatarStack.tsx
@@ -14,7 +14,7 @@ export default function RoomAvatarStack({ id }: { id: string }) {
           images: new LiveMap(),
             music: new LiveObject({ id: '', playing: false, volume: 5 }),
 
-          summary: new LiveObject({ acts: [] }),
+          summary: new LiveObject({ acts: new LiveList<{ id: string; title: string }>([]) }),
           quickNote: new LiveObject({ text: '', updatedAt: 0 }),
 
           editor: new LiveMap(),

--- a/liveblocks.config.ts
+++ b/liveblocks.config.ts
@@ -54,7 +54,7 @@ declare global {
       images: LiveMap<string, CanvasImage>
         music: LiveObject<{ id: string; playing: boolean; volume: number }>
 
-      summary: LiveObject<{ acts: Array<{ id: string; title: string }>; currentId?: string }>
+      summary: LiveObject<{ acts: LiveList<{ id: string; title: string }>; currentId?: string }>
       quickNote: LiveObject<{ text: string; updatedAt: number }>
 
       editor: LiveMap<string, string>


### PR DESCRIPTION
## Summary
- adjust summary storage type to use LiveList
- seed default room storage with LiveList based summary

## Testing
- `npm test`
- `npm run type-check`
- `npm run build` *(fails: Invalid value for field 'secret'. Secret keys must start with 'sk_')*


------
https://chatgpt.com/codex/tasks/task_e_68b453981424832e85e76c3fb837fa4b