### PR TITLE
fix: handle character selection

### DIFF
--- a/components/menu/CharacterList.tsx
+++ b/components/menu/CharacterList.tsx
@@ -110,17 +110,9 @@ const CharacterList: FC<Props> = ({
                 return (
                   <motion.li
                     key={`${ch.owner}:${ch.id}`}
-                    onClick={() =>
-                      onSelect(
-                        local
-                          ? filtered.findIndex(
-                              (c) =>
-                                String(c.id) === String(ch.id) &&
-                                c.owner === ch.owner,
-                            )
-                          : -1,
-                      )
-                    }
+                    onClick={() => {
+                      onSelect(local ? localIdx : -1)
+                    }}
                     className={`
                   group relative rounded-lg p-3 cursor-pointer
                   flex flex-col gap-2 min-h-[120px]

--- a/components/menu/MenuAccueil.tsx
+++ b/components/menu/MenuAccueil.tsx
@@ -395,8 +395,13 @@ export default function MenuAccueil() {
     : []
 
   const handleSelectChar = (idx: number) => {
+    if (idx === -1) {
+      setSelectedIdx(null)
+      localStorage.removeItem(SELECTED_KEY)
+      return
+    }
     setSelectedIdx(idx)
-      const ch = filteredCharacters.at(idx)
+    const ch = filteredCharacters.at(idx)
     if (ch?.id !== undefined) {
       localStorage.setItem(SELECTED_KEY, String(ch.id))
     }


### PR DESCRIPTION
## Summary
- avoid selecting last character when clicking remote entries
- clear local selection when remote entry clicked

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4584c0b58832e94d0c4153ed93c77