### PR TITLE
fix: avoid duplicate dice messages

### DIFF
--- a/components/app/HomePageInner.tsx
+++ b/components/app/HomePageInner.tsx
@@ -172,9 +172,7 @@ export default function HomePageInner() {
 
     const ts = Date.now()
     const entry = { player: nom, dice, result, ts }
-    setHistory((h) => [...h, entry])
     broadcast({ type: 'dice-roll', player: nom, dice, result, ts } as Liveblocks['RoomEvent'])
-    addEvent({ id: crypto.randomUUID(), kind: 'dice', player: nom, dice, result, ts })
     debug('dice-roll send', entry)
     setPendingRoll(null)
 


### PR DESCRIPTION
## Summary
- remove local dice roll logging so events aren't duplicated in chat

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b45d1d2e9c832e9ac68e832ca7c5cc