### PR TITLE
feat: store music volume locally

### DIFF
--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -30,7 +30,7 @@ export function Room({
         initialStorage={{
           characters: new LiveMap(),
           images: new LiveMap(),
-            music: new LiveObject({ id: '', playing: false, volume: 5 }),
+          music: new LiveObject({ id: '', playing: false }),
           summary: new LiveObject({ acts: [], currentId: '' }),
           editor: new LiveMap(),
           events: new LiveList([]),

--- a/components/canvas/InteractiveCanvas.tsx
+++ b/components/canvas/InteractiveCanvas.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import { useRef, useState, useEffect } from 'react'
+import { useRef, useState, useEffect, useMemo } from 'react'
 import {
   useBroadcastEvent,
   useEventListener,
   useStorage,
   useMutation,
   useMyPresence,
+  useRoom,
+  useSelf,
 } from '@liveblocks/react'
 import LiveCursors from './LiveCursors'
 import YouTube from 'react-youtube'
@@ -20,12 +22,17 @@ import SideNotes from '@/components/misc/SideNotes'
 export default function InteractiveCanvas() {
   // `images` map is created by RoomProvider but may be null until ready
   const imagesMap = useStorage((root) => root.images)
-  const images = imagesMap
-    ? (Array.from(imagesMap.values()) as ImageData[])
-    : []
+  const images = useMemo(
+    () => (imagesMap ? (Array.from(imagesMap.values()) as ImageData[]) : []),
+    [imagesMap],
+  )
 
   const musicObj = useStorage((root) => root.music) // peut être null au démarrage
   const storageReady = Boolean(musicObj)
+
+  const room = useRoom()
+  const self = useSelf()
+  const volumeKey = room && self ? `volume-${room.id}-${self.id}` : undefined
 
   const [isDrawing, setIsDrawing] = useState(false)
   const [drawMode, setDrawMode] = useState<ToolMode>('images')
@@ -43,12 +50,24 @@ export default function InteractiveCanvas() {
   // Lecture: synchro globale
   const [isPlaying, setIsPlaying] = useState(false)
 
-  // Volume: synchro globale (0..100), défaut 5%
+  // Volume: local (0..100), défaut 5%
   const [volume, setVolumeState] = useState(5)
   const setVolume = (v: number) => {
     setVolumeState(v)
-    if (storageReady) updateMusic({ volume: v })
+    if (volumeKey) localStorage.setItem(volumeKey, String(v))
   }
+
+  useEffect(() => {
+    if (!volumeKey) return
+    const stored = localStorage.getItem(volumeKey)
+    if (stored !== null) {
+      const v = parseInt(stored, 10)
+      setVolumeState(Number.isNaN(v) ? 5 : v)
+    } else {
+      setVolumeState(5)
+      localStorage.setItem(volumeKey, '5')
+    }
+  }, [volumeKey])
 
   const broadcast = useBroadcastEvent()
   const lastSend = useRef(0)
@@ -87,11 +106,11 @@ export default function InteractiveCanvas() {
     })
   }, [])
 
-  // Mutation musique: gère l'état global (id, lecture, volume)
+  // Mutation musique: gère l'état global (id, lecture)
   const updateMusic = useMutation(
     (
       { storage },
-      updates: { id?: string; playing?: boolean; volume?: number },
+      updates: { id?: string; playing?: boolean },
     ) => {
       storage.get('music').update(updates)
     },
@@ -129,27 +148,40 @@ export default function InteractiveCanvas() {
   const ERASE_MIN = DRAW_MIN * 4
   const ERASE_MAX = DRAW_MAX * 4
 
-    useEffect(() => {
-      const resize = () => {
-        const canvas = drawingCanvasRef.current
-        if (canvas) {
-          const rect = canvas.getBoundingClientRect()
-          const dpr = window.devicePixelRatio || 1
-          canvas.width = rect.width * dpr
-          canvas.height = rect.height * dpr
-          const ctx = canvas.getContext('2d')
-          if (ctx) {
-            ctx.scale(dpr, dpr)
-            ctx.lineCap = 'round'
-            ctx.lineJoin = 'round'
-            ctxRef.current = ctx
+  function clampImage(img: ImageData, rect: DOMRect) {
+    return {
+      x: Math.max(0, Math.min(img.x, rect.width - img.width)),
+      y: Math.max(0, Math.min(img.y, rect.height - img.height)),
+    }
+  }
+
+  useEffect(() => {
+    const resize = () => {
+      const canvas = drawingCanvasRef.current
+      if (canvas) {
+        const rect = canvas.getBoundingClientRect()
+        const dpr = window.devicePixelRatio || 1
+        canvas.width = rect.width * dpr
+        canvas.height = rect.height * dpr
+        const ctx = canvas.getContext('2d')
+        if (ctx) {
+          ctx.scale(dpr, dpr)
+          ctx.lineCap = 'round'
+          ctx.lineJoin = 'round'
+          ctxRef.current = ctx
+        }
+        for (const img of images) {
+          const clamped = clampImage(img, rect)
+          if (clamped.x !== img.x || clamped.y !== img.y) {
+            updateImage({ ...img, ...clamped })
           }
         }
       }
-      resize()
-      window.addEventListener('resize', resize)
-      return () => window.removeEventListener('resize', resize)
-    }, [toolsVisible, audioVisible])
+    }
+    resize()
+    window.addEventListener('resize', resize)
+    return () => window.removeEventListener('resize', resize)
+  }, [toolsVisible, audioVisible, images, updateImage])
 
   useEffect(() => {
     const canvas = drawingCanvasRef.current
@@ -186,7 +218,6 @@ export default function InteractiveCanvas() {
     if (!musicObj) return
     setYtId(musicObj.id)
     setIsPlaying(!!musicObj.playing)
-    setVolumeState(musicObj.volume ?? 5)
   }, [musicObj])
 
   // --------- DnD images: aperçu instantané + swap vers Cloudinary optimisé ---------

--- a/components/rooms/RoomAvatarStack.tsx
+++ b/components/rooms/RoomAvatarStack.tsx
@@ -9,15 +9,15 @@ export default function RoomAvatarStack({ id }: { id: string }) {
       <RoomProvider
         id={id}
         initialPresence={{}}
-        initialStorage={{
-          characters: new LiveMap(),
-          images: new LiveMap(),
-            music: new LiveObject({ id: '', playing: false, volume: 5 }),
-          summary: new LiveObject({ acts: [] }),
-          editor: new LiveMap(),
-          events: new LiveList([]),
-          rooms: new LiveList([])
-        }}
+          initialStorage={{
+            characters: new LiveMap(),
+            images: new LiveMap(),
+            music: new LiveObject({ id: '', playing: false }),
+            summary: new LiveObject({ acts: [], currentId: '' }),
+            editor: new LiveMap(),
+            events: new LiveList([]),
+            rooms: new LiveList([]),
+          }}
       >
         <ClientSideSuspense fallback={null}>
           <LiveAvatarStack className="absolute right-2 top-1/2 -translate-y-1/2 flex flex-row-reverse gap-1" size={20} />

--- a/liveblocks.config.ts
+++ b/liveblocks.config.ts
@@ -50,8 +50,8 @@ declare global {
     Storage: {
       characters: LiveMap<string, CharacterData>
       images: LiveMap<string, CanvasImage>
-        music: LiveObject<{ id: string; playing: boolean; volume: number }>
-      summary: LiveObject<{ acts: Array<{ id: string; title: string }> }>
+      music: LiveObject<{ id: string; playing: boolean }>
+      summary: LiveObject<{ acts: Array<{ id: string; title: string }>; currentId?: string }>
       editor: LiveMap<string, string>
       events: LiveList<SessionEvent>
       rooms: LiveList<Room>


### PR DESCRIPTION
## Summary
- persist music volume per user using localStorage
- drop volume and quickNote from Liveblocks state and align summary typing
- clamp images to canvas on resize without undefined ref
- initialize summary currentId in avatar stack

## Testing
- `npm test`
- `npm run build` *(fails: Invalid value for field 'secret')*


------
https://chatgpt.com/codex/tasks/task_e_68b41e401e60832e892592d162054345