### PR TITLE
Improve image drag performance

### DIFF
--- a/components/canvas/ImageItem.tsx
+++ b/components/canvas/ImageItem.tsx
@@ -64,4 +64,7 @@ const ImageItem: React.FC<Props> = ({ img, drawMode, onPointerDown, onDelete }) 
   </div>
 )
 
-export default ImageItem
+export default React.memo(
+  ImageItem,
+  (prev, next) => prev.img === next.img && prev.drawMode === next.drawMode,
+)


### PR DESCRIPTION
## Summary
- Reduce lag by tracking image drags locally and updating shared state only on release
- Memoize ImageItem components to prevent unnecessary re-renders

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b45fc41f54832ea598812069d3abbf