### PR TITLE
fix: preserve canvas when leaving room

### DIFF
--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -1,6 +1,12 @@
 "use client";
-import { ReactNode } from "react";
-import { LiveblocksProvider, RoomProvider, ClientSideSuspense } from "@liveblocks/react/suspense";
+import { ReactNode, useEffect } from "react";
+import {
+  LiveblocksProvider,
+  RoomProvider,
+  ClientSideSuspense,
+  useMutation,
+  useStorage,
+} from "@liveblocks/react/suspense";
 import { LiveMap, LiveObject, LiveList } from '@liveblocks/client'
 
 export function Room({
@@ -27,20 +33,50 @@ export function Room({
       <RoomProvider
         id={id}
         initialPresence={{}}
-        initialStorage={{
-          characters: new LiveMap(),
-          images: new LiveMap(),
-            music: new LiveObject({ id: '', playing: false, volume: 5 }),
-          summary: new LiveObject({ acts: [], currentId: '' }),
-          editor: new LiveMap(),
-          events: new LiveList([]),
-          rooms: new LiveList([])
-        }}
+        initialStorage={undefined as unknown as Liveblocks['Storage']}
       >
         <ClientSideSuspense fallback={<div>Loading…</div>}>
-          {children}
+          <StorageInitializer>{children}</StorageInitializer>
         </ClientSideSuspense>
       </RoomProvider>
     </LiveblocksProvider>
   );
+}
+
+function StorageInitializer({ children }: { children: ReactNode }) {
+  const init = useMutation(({ storage }) => {
+    if (!storage.get('characters')) storage.set('characters', new LiveMap());
+    if (!storage.get('images')) storage.set('images', new LiveMap());
+    if (!storage.get('music'))
+      storage.set('music', new LiveObject({ id: '', playing: false, volume: 5 }));
+    if (!storage.get('summary'))
+      storage.set(
+        'summary',
+        new LiveObject({ acts: new LiveList<{ id: string; title: string }>([]), currentId: '' }),
+      );
+    if (!storage.get('editor')) storage.set('editor', new LiveMap());
+    if (!storage.get('events')) storage.set('events', new LiveList([]));
+    if (!storage.get('rooms')) storage.set('rooms', new LiveList([]));
+  }, []);
+
+  const ready = useStorage(
+    root =>
+      !!root.characters &&
+      !!root.images &&
+      !!root.music &&
+      !!root.summary &&
+      !!root.editor &&
+      !!root.events &&
+      !!root.rooms,
+  );
+
+  useEffect(() => {
+    if (!ready) init();
+  }, [ready, init]);
+
+  if (!ready) {
+    return <div>Loading…</div>;
+  }
+
+  return <>{children}</>;
 }

--- a/components/chat/SessionSummary.tsx
+++ b/components/chat/SessionSummary.tsx
@@ -7,7 +7,6 @@
 //
 // ───────────────────────────────────────────────────────────────────────────────────────────
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 'use client'
 
 import React, {
@@ -22,7 +21,7 @@ import { useT } from '@/lib/useT'
 
 // ====== Liveblocks (collaboratif) ======
 import { useStorage, useMutation, useStatus } from '@liveblocks/react'
-import { LiveMap, LiveObject } from '@liveblocks/client'
+import { LiveList, LiveMap, LiveObject } from '@liveblocks/client'
 import type { LsonObject } from '@liveblocks/client'
 
 // ====== Lexical ======
@@ -48,10 +47,8 @@ interface Props {
   onClose: () => void
 }
 
-// [FIX] Déclaration manquante : le type Summary était utilisé mais non défini.
-//      Ajout d'un simple LsonObject avec acts/currentId pour typer LiveObject<Summary>.
 interface Summary extends LsonObject {
-  acts: Page[]
+  acts: LiveList<Page>
   currentId?: string
 }
 
@@ -273,8 +270,7 @@ function LocalSummary({
         editor[id] = content
       })
 
-      // [FIX] Fin manquante : mise à jour de l'état + reset input
-      const next = {
+        const next = {
         ...state,
         acts: [...state.acts, ...incoming],
         currentId: incoming[0]?.id ?? state.currentId,
@@ -398,39 +394,41 @@ function LiveSummary({
 
   // Sélecteurs Liveblocks (peuvent être undefined avant init)
   const summary = useStorage((root) => root.summary) as
-    | Summary
     | LiveObject<Summary>
-    | undefined
+    | null
 
   const rawEditor = useStorage((root) => root.editor)
   const editorMap =
     rawEditor instanceof LiveMap ? (rawEditor as LiveMap<string, string>) : null
 
   // Normalisation pages / currentId
-  const pages =
-    summary instanceof LiveObject
-      ? ((summary.get('acts') as Page[] | undefined) ?? undefined)
-      : (summary?.acts as Page[] | undefined)
+  const pages = summary
+    ? (summary.get('acts') as LiveList<Page>).toArray()
+    : undefined
 
-  const currentId =
-    summary instanceof LiveObject
-      ? ((summary.get('currentId') as string | undefined) ?? undefined)
-      : (summary?.currentId as string | undefined)
+  const currentId = summary
+    ? ((summary.get('currentId') as string | undefined) ?? undefined)
+    : undefined
 
   const [editorKey, setEditorKey] = useState(0)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const getOrInitSummary = (storage: LiveObject<any>) => {
+    const existing = storage.get('summary')
+    if (existing instanceof LiveObject) return existing as LiveObject<Summary>
+    const summary = new LiveObject<Summary>({
+      acts: new LiveList<Page>([]),
+      currentId: undefined,
+    })
+    storage.set('summary', summary)
+    return summary
+  }
+
   // Mutations sûres (créent les structures si nécessaires)
   const ensureStorageShape = useMutation(({ storage }) => {
-    const s = storage.get('summary')
-    if (!(s instanceof LiveObject)) {
-      storage.set(
-        'summary',
-        new LiveObject<Summary>({ acts: [], currentId: undefined }),
-      )
-    }
-    const e = storage.get('editor')
-    if (!(e instanceof LiveMap)) {
+    getOrInitSummary(storage)
+    if (!(storage.get('editor') instanceof LiveMap)) {
       storage.set('editor', new LiveMap<string, string>())
     }
   }, [])
@@ -439,33 +437,30 @@ function LiveSummary({
     ensureStorageShape()
   }, [ensureStorageShape])
 
-  const updatePages = useMutation(({ storage }, acts: Page[]) => {
-    let s = storage.get('summary')
-    if (!(s instanceof LiveObject)) {
-      s = new LiveObject<Summary>({ acts: [], currentId: undefined })
-      storage.set('summary', s)
-    }
-    ;(s as LiveObject<Summary>).update({ acts })
+  const addPage = useMutation(({ storage }, page: Page) => {
+    const summary = getOrInitSummary(storage)
+    const list = summary.get('acts') as LiveList<Page>
+    list.push(page)
+  }, [])
+
+  const renamePage = useMutation(({ storage }, page: Page) => {
+    const summary = getOrInitSummary(storage)
+    const list = summary.get('acts') as LiveList<Page>
+    const index = list.toArray().findIndex((p) => p.id === page.id)
+    if (index !== -1) list.set(index, page)
   }, [])
 
   const updateCurrentId = useMutation(({ storage }, id: string | undefined) => {
-    let s = storage.get('summary')
-    if (!(s instanceof LiveObject)) {
-      s = new LiveObject<Summary>({ acts: [], currentId: undefined })
-      storage.set('summary', s)
-    }
-    ;(s as LiveObject<Summary>).update({ currentId: id })
+    const summary = getOrInitSummary(storage)
+    summary.update({ currentId: id })
   }, [])
 
   const deletePage = useMutation(({ storage }, id: string) => {
-    let s = storage.get('summary')
-    if (!(s instanceof LiveObject)) {
-      s = new LiveObject<Summary>({ acts: [], currentId: undefined })
-      storage.set('summary', s)
-    }
-    const acts = ((s as LiveObject<any>).get('acts') as Page[]) || []
-    ;(s as LiveObject<any>).update({ acts: acts.filter((p: Page) => p.id !== id) })
-  }, []) // [FIX] accolade + tableau de dépendances manquants
+    const summary = getOrInitSummary(storage)
+    const list = summary.get('acts') as LiveList<Page>
+    const index = list.toArray().findIndex((p) => p.id === id)
+    if (index !== -1) list.delete(index)
+  }, [])
 
   const updateEditor = useMutation(
     ({ storage }, data: { id: string; content: string }) => {
@@ -485,7 +480,7 @@ function LiveSummary({
     if (pages.length === 0) {
       const title = (t('pageNamePrompt') as string) || 'New page'
       const newPage = { id: crypto.randomUUID(), title }
-      updatePages([newPage])
+      addPage(newPage)
       updateEditor({ id: newPage.id, content: '' })
       updateCurrentId(newPage.id)
       setEditorKey((k) => k + 1)
@@ -513,7 +508,7 @@ function LiveSummary({
   // Actions UI
   const createPage = (title: string) => {
     const newPage = { id: crypto.randomUUID(), title }
-    updatePages([...(pages || []), newPage])
+    addPage(newPage)
     updateEditor({ id: newPage.id, content: '' })
     updateCurrentId(newPage.id)
     setEditorKey((k) => k + 1)
@@ -521,10 +516,7 @@ function LiveSummary({
 
   const handleTitleChange = (title: string) => {
     if (!pages || !current) return
-    const updatedPages = pages.map((p) =>
-      p.id === current.id ? { ...p, title } : p,
-    )
-    updatePages(updatedPages)
+    renamePage({ ...current, title })
   }
 
   const handleDelete = () => {
@@ -553,7 +545,7 @@ function LiveSummary({
       .text()
       .then((text) => {
         const parts = text.split(/=== Page: /).slice(1)
-        const newPages: Page[] = []
+        let firstId: string | undefined
         parts.forEach((part) => {
           const [titleLine = '', ...contentLines] = part.split('\n')
           const title =
@@ -562,12 +554,12 @@ function LiveSummary({
             'New page'
           const content = contentLines.join('\n').trim()
           const id = crypto.randomUUID()
-          newPages.push({ id, title })
+          addPage({ id, title })
           updateEditor({ id, content })
+          if (!firstId) firstId = id
         })
-        if (newPages.length > 0) {
-          updatePages([...(pages || []), ...newPages])
-          updateCurrentId(newPages[0]!.id)
+        if (firstId) {
+          updateCurrentId(firstId)
           setEditorKey((k) => k + 1)
         }
         if (fileInputRef.current) fileInputRef.current.value = ''

--- a/components/rooms/RoomAvatarStack.tsx
+++ b/components/rooms/RoomAvatarStack.tsx
@@ -1,6 +1,5 @@
 'use client'
 import { LiveblocksProvider, RoomProvider, ClientSideSuspense } from '@liveblocks/react/suspense'
-import { LiveMap, LiveObject, LiveList } from '@liveblocks/client'
 import LiveAvatarStack from '../chat/LiveAvatarStack'
 
 export default function RoomAvatarStack({ id }: { id: string }) {
@@ -9,15 +8,7 @@ export default function RoomAvatarStack({ id }: { id: string }) {
       <RoomProvider
         id={id}
         initialPresence={{}}
-        initialStorage={{
-          characters: new LiveMap(),
-          images: new LiveMap(),
-            music: new LiveObject({ id: '', playing: false, volume: 5 }),
-          summary: new LiveObject({ acts: [] }),
-          editor: new LiveMap(),
-          events: new LiveList([]),
-          rooms: new LiveList([])
-        }}
+        initialStorage={undefined as unknown as Liveblocks['Storage']}
       >
         <ClientSideSuspense fallback={null}>
           <LiveAvatarStack className="absolute right-2 top-1/2 -translate-y-1/2 flex flex-row-reverse gap-1" size={20} />

--- a/liveblocks.config.ts
+++ b/liveblocks.config.ts
@@ -47,15 +47,18 @@ declare global {
     }
 
     // The Storage tree for the room, for useMutation, useStorage, etc.
-    Storage: {
-      characters: LiveMap<string, CharacterData>
-      images: LiveMap<string, CanvasImage>
-        music: LiveObject<{ id: string; playing: boolean; volume: number }>
-      summary: LiveObject<{ acts: Array<{ id: string; title: string }> }>
-      editor: LiveMap<string, string>
-      events: LiveList<SessionEvent>
-      rooms: LiveList<Room>
-    }
+      Storage: {
+        characters: LiveMap<string, CharacterData>;
+        images: LiveMap<string, CanvasImage>;
+        music: LiveObject<{ id: string; playing: boolean; volume: number }>;
+        summary: LiveObject<{
+          acts: LiveList<{ id: string; title: string }>;
+          currentId?: string;
+        }>;
+        editor: LiveMap<string, string>;
+        events: LiveList<SessionEvent>;
+        rooms: LiveList<Room>;
+      };
 
     // Custom user info set when authenticating with a secret key
     UserMeta: {


### PR DESCRIPTION
## Summary
- type summary storage with LiveList pages and optional currentId
- update SessionSummary to initialize and mutate LiveList-backed pages
- seed summary with a typed LiveList in the room storage initializer
- fix linter warnings in summary mutations
- dedupe summary mutations behind a shared initializer
- mutate summary pages and titles via LiveList operations instead of replacing the list

## Testing
- `npm test`
- `npm run build` *(fails: Invalid value for field 'secret'. Secret keys must start with 'sk_')*


------
https://chatgpt.com/codex/tasks/task_e_68b41e3aed14832ea0442768cd84d3df