### PR TITLE
fix: stabilize canvas images and dragging

### DIFF
--- a/components/canvas/ImageItem.tsx
+++ b/components/canvas/ImageItem.tsx
@@ -6,29 +6,50 @@ import React from 'react'
 import { ToolMode } from './CanvasTools'
 
 // Single image element on canvas with move/resize handles.
-
 export interface ImageData {
-  id: number
-  src: string
+  id: string
+  url: string
   x: number
   y: number
   width: number
   height: number
+  scale: number
+  rotation: number
+  createdAt: number
 }
 
 interface Props {
   img: ImageData
   drawMode: ToolMode
-  onPointerDown: (e: React.PointerEvent, id: number, type: 'move' | 'resize') => void
-  onDelete: (id: number) => void
+  onPointerDown: (
+    e: React.PointerEvent,
+    id: string,
+    type: 'move' | 'resize',
+  ) => void
+  onDelete: (id: string) => void
+  onError: (id: string) => void
+  pending?: boolean
 }
 
-const ImageItem: React.FC<Props> = ({ img, drawMode, onPointerDown, onDelete }) => (
+const ImageItem: React.FC<Props> = ({
+  img,
+  drawMode,
+  onPointerDown,
+  onDelete,
+  onError,
+  pending,
+}) => (
   <div
     className="absolute border border-white/20 rounded-2xl shadow-md group touch-none transition-all duration-300"
-    style={{ top: img.y, left: img.x, width: img.width, height: img.height, zIndex: 1 }}
+    style={{
+      top: img.y,
+      left: img.x,
+      width: img.width,
+      height: img.height,
+      zIndex: 1,
+    }}
   >
-    {drawMode === 'images' && (
+    {drawMode === 'images' && !pending && (
       <button
         onClick={() => onDelete(img.id)}
         className="absolute top-1 left-1 z-20 p-1 rounded-full bg-black/60 hover:bg-red-600 transition text-white opacity-80 group-hover:opacity-100"
@@ -39,23 +60,24 @@ const ImageItem: React.FC<Props> = ({ img, drawMode, onPointerDown, onDelete }) 
       </button>
     )}
     <Image
-      src={img.src}
+      src={img.url}
       alt="Dropped"
       width={img.width}
       height={img.height}
       className="w-full h-full object-contain pointer-events-none select-none rounded-2xl"
       style={{ borderRadius: '1rem' }}
+      onError={() => onError(img.id)}
       unoptimized
     />
-    {drawMode === 'images' && (
+    {drawMode === 'images' && !pending && (
       <>
         <div
-          onPointerDown={e => onPointerDown(e, img.id, 'move')}
+          onPointerDown={(e) => onPointerDown(e, img.id, 'move')}
           className="absolute top-0 left-0 w-full h-full cursor-move"
           style={{ zIndex: 3 }}
         />
         <div
-          onPointerDown={e => onPointerDown(e, img.id, 'resize')}
+          onPointerDown={(e) => onPointerDown(e, img.id, 'resize')}
           className="absolute bottom-0 right-0 w-4 h-4 bg-white/40 border border-white rounded-full cursor-se-resize"
           style={{ zIndex: 4 }}
         />

--- a/components/canvas/InteractiveCanvas.tsx
+++ b/components/canvas/InteractiveCanvas.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef, useState, useEffect } from 'react'
+import { useRef, useState, useEffect, useReducer } from 'react'
 import {
   useBroadcastEvent,
   useEventListener,
@@ -33,8 +33,25 @@ export default function InteractiveCanvas() {
   const images = imagesMap
     ? (Array.from(imagesMap.values()) as ImageData[])
     : []
-  const [dragImages, setDragImages] = useState<ImageData[] | null>(null)
-  const imagesToRender = dragImages ?? images
+  const [pendingImages, setPendingImages] = useState<ImageData[]>([])
+  const localTransforms = useRef<Map<string, Partial<ImageData>>>(new Map())
+  const [, forceRender] = useReducer((x: number) => x + 1, 0)
+  const rafPending = useRef(false)
+  const scheduleRender = () => {
+    if (rafPending.current) return
+    rafPending.current = true
+    requestAnimationFrame(() => {
+      rafPending.current = false
+      forceRender()
+    })
+  }
+  const imagesToRender = [
+    ...images.map((img) => {
+      const local = localTransforms.current.get(img.id)
+      return local ? { ...img, ...local } : img
+    }),
+    ...pendingImages,
+  ]
 
   const musicObj = useStorage((root) => root.music) // peut être null au démarrage
   const storageReady = Boolean(musicObj)
@@ -65,6 +82,8 @@ export default function InteractiveCanvas() {
   const broadcast = useBroadcastEvent()
   const lastSend = useRef(0)
   const THROTTLE = 0
+  const lastMutation = useRef(0)
+  const MUTATION_THROTTLE = 100
   const [, updateMyPresence] = useMyPresence()
 
   const canvasRef = useRef<HTMLDivElement>(null)
@@ -82,15 +101,26 @@ export default function InteractiveCanvas() {
   }, [updateMyPresence])
 
   const addImage = useMutation(({ storage }, img: ImageData) => {
-    storage.get('images').set(String(img.id), img)
+    storage.get('images').set(img.id, img)
   }, [])
 
-  const updateImage = useMutation(({ storage }, img: ImageData) => {
-    storage.get('images').set(String(img.id), img)
-  }, [])
+  const updateImageTransform = useMutation(
+    (
+      { storage },
+      id: string,
+      updates: Partial<ImageData>,
+    ) => {
+      const map = storage.get('images')
+      const current = map.get(id)
+      if (current) {
+        map.set(id, { ...current, ...updates })
+      }
+    },
+    [],
+  )
 
-  const deleteImage = useMutation(({ storage }, id: number) => {
-    storage.get('images').delete(String(id))
+  const removeImage = useMutation(({ storage }, id: string) => {
+    storage.get('images').delete(id)
   }, [])
 
   const clearImages = useMutation(({ storage }) => {
@@ -101,6 +131,8 @@ export default function InteractiveCanvas() {
   }, [])
 
   const IMAGE_MIN_SIZE = 50
+  const ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/jpg', 'image/webp']
+  const MAX_SIZE_MB = 5
 
   const clampImage = (img: ImageData, rect: DOMRect): ImageData => {
     const width = Math.min(Math.max(img.width, IMAGE_MIN_SIZE), rect.width - img.x)
@@ -153,7 +185,7 @@ export default function InteractiveCanvas() {
   })
 
   const dragState = useRef({
-    id: null as number | null,
+    id: null as string | null,
     type: null as 'move' | 'resize' | null,
     offsetX: 0,
     offsetY: 0,
@@ -221,7 +253,7 @@ export default function InteractiveCanvas() {
           clamped.width !== img.width ||
           clamped.height !== img.height
         ) {
-          updateImage(clamped)
+          updateImageTransform(img.id, clamped)
         }
       })
     }
@@ -231,7 +263,7 @@ export default function InteractiveCanvas() {
       window.removeEventListener('resize', handleResize)
       window.removeEventListener('orientationchange', handleResize)
     }
-  }, [updateImage])
+  }, [updateImageTransform])
 
   useEffect(() => {
     if (drawMode === 'erase') {
@@ -276,54 +308,60 @@ export default function InteractiveCanvas() {
     dropY: number,
     rect: DOMRect,
   ) {
-    const localUrl = fileToObjectURL(file)
-    const tempId = Date.now() + Math.random()
-    const tempImg: ImageData = {
-      id: tempId,
-      src: localUrl,
-      x: dropX - 100,
-      y: dropY - 100,
-      width: 200,
-      height: 200,
+    if (!ALLOWED_TYPES.includes(file.type) || file.size > MAX_SIZE_MB * 1024 * 1024) {
+      alert('Invalid image file')
+      return
     }
-    const clampedTemp = clampImage(tempImg, rect)
-    setDragImages((prev) => [ ...(prev ?? images), clampedTemp ])
-
+    const localUrl = fileToObjectURL(file)
+    const id = crypto.randomUUID()
+    const tempImg: ImageData = clampImage(
+      {
+        id,
+        url: localUrl,
+        x: dropX - 100,
+        y: dropY - 100,
+        width: 200,
+        height: 200,
+        scale: 1,
+        rotation: 0,
+        createdAt: Date.now(),
+      },
+      rect,
+    )
+    setPendingImages((prev) => [...prev, tempImg])
     try {
       const form = new FormData()
       form.append('file', file)
       form.append('upload_preset', 'cakejdr-images')
-
       const res = await fetch('/api/cloudinary', { method: 'POST', body: form })
       const data = await res.json().catch(() => null)
-
       if (!res.ok || !data) {
         throw new Error(data?.error || 'Upload failed')
       }
-
       const finalUrl: string = data.deliveryUrl || data.url
       if (!finalUrl) {
         throw new Error('No URL returned by Cloudinary endpoint')
       }
-
-      const width: number = data.width ?? clampedTemp.width
-      const height: number = data.height ?? clampedTemp.height
+      const width: number = data.width ?? tempImg.width
+      const height: number = data.height ?? tempImg.height
       const finalImg: ImageData = clampImage(
         {
-          id: tempId,
-          src: finalUrl,
+          ...tempImg,
+          url: finalUrl,
           x: dropX - width / 2,
           y: dropY - height / 2,
           width,
           height,
+          createdAt: Date.now(),
         },
         rect,
       )
       addImage(finalImg)
     } catch (err) {
       console.error(err)
+      alert('Image upload failed')
     } finally {
-      setDragImages(null)
+      setPendingImages((prev) => prev.filter((i) => i.id !== id))
       URL.revokeObjectURL(localUrl)
     }
   }
@@ -347,11 +385,11 @@ export default function InteractiveCanvas() {
 
   // --------------------------------------------------------------------------
 
-  const [selectedImageId, setSelectedImageId] = useState<number | null>(null)
+  const [selectedImageId, setSelectedImageId] = useState<string | null>(null)
 
   const handlePointerDown = (
     e: React.PointerEvent,
-    id?: number,
+    id?: string,
     type?: 'move' | 'resize',
   ) => {
     e.preventDefault()
@@ -376,7 +414,7 @@ export default function InteractiveCanvas() {
     }
 
     if (drawMode === 'images' && id && type) {
-      const img = imagesToRender.find((i) => i.id === id)
+      const img = images.find((i) => i.id === id)
       if (!img) return
 
       dragState.current = {
@@ -385,7 +423,18 @@ export default function InteractiveCanvas() {
         offsetX: e.clientX - rect.left - img.x,
         offsetY: e.clientY - rect.top - img.y,
       }
-      setDragImages(images.map((i) => ({ ...i })))
+      localTransforms.current.set(id, {
+        x: img.x,
+        y: img.y,
+        width: img.width,
+        height: img.height,
+        scale: img.scale,
+        rotation: img.rotation,
+        createdAt: img.createdAt,
+        url: img.url,
+        id: img.id,
+      })
+      scheduleRender()
       setSelectedImageId(id)
     }
   }
@@ -432,28 +481,33 @@ export default function InteractiveCanvas() {
     }
 
     const { id, type, offsetX, offsetY } = dragState.current
-    if (!id || !type || !dragImages) return
-    const img = dragImages.find((i) => i.id === id)
-    if (!img) return
+    if (!id || !type) return
+    const base =
+      localTransforms.current.get(id) || images.find((i) => i.id === id)
+    if (!base) return
     const updated =
       type === 'move'
-        ? { ...img, x: x - offsetX, y: y - offsetY }
-        : { ...img, width: x - img.x, height: y - img.y }
-    const clamped = clampImage(updated, rect)
-    setDragImages((prev) =>
-      prev ? prev.map((i) => (i.id === id ? clamped : i)) : prev,
-    )
-    updateImage(clamped)
+        ? { ...base, x: x - offsetX, y: y - offsetY }
+        : { ...base, width: x - base.x, height: y - base.y }
+    const clamped = clampImage(updated as ImageData, rect)
+    localTransforms.current.set(id, clamped)
+    scheduleRender()
+    const now = Date.now()
+    if (now - lastMutation.current > MUTATION_THROTTLE) {
+      lastMutation.current = now
+      updateImageTransform(id, clamped)
+    }
   }
 
   const handlePointerUp = () => {
     setIsDrawing(false)
     const { id } = dragState.current
-    if (id && dragImages) {
-      const img = dragImages.find((i) => i.id === id)
-      if (img) updateImage(img)
+    if (id) {
+      const local = localTransforms.current.get(id)
+      if (local) updateImageTransform(id, local)
+      localTransforms.current.delete(id)
+      scheduleRender()
     }
-    setDragImages(null)
     dragState.current = { id: null, type: null, offsetX: 0, offsetY: 0 }
   }
 
@@ -476,7 +530,9 @@ export default function InteractiveCanvas() {
     updated = clampImage(updated, rect)
     if (updated.x !== img.x || updated.y !== img.y) {
       e.preventDefault()
-      updateImage(updated)
+      localTransforms.current.set(img.id, updated)
+      scheduleRender()
+      updateImageTransform(img.id, updated)
     }
   }
 
@@ -498,8 +554,13 @@ export default function InteractiveCanvas() {
     }
   }
 
-  const handleDeleteImage = (id: number) => {
-    deleteImage(id)
+  const handleDeleteImage = (id: string) => {
+    removeImage(id)
+  }
+
+  const handleImageError = (id: string) => {
+    removeImage(id)
+    alert('Image failed to load')
   }
 
   const handleYtSubmit = () => {
@@ -623,6 +684,8 @@ export default function InteractiveCanvas() {
               drawMode={drawMode}
               onPointerDown={handlePointerDown}
               onDelete={handleDeleteImage}
+              onError={handleImageError}
+              pending={pendingImages.some((p) => p.id === img.id)}
             />
           ))}
 

--- a/components/canvas/InteractiveCanvas.tsx
+++ b/components/canvas/InteractiveCanvas.tsx
@@ -482,9 +482,9 @@ export default function InteractiveCanvas() {
 
     const { id, type, offsetX, offsetY } = dragState.current
     if (!id || !type) return
-    const base =
-      localTransforms.current.get(id) || images.find((i) => i.id === id)
-    if (!base) return
+    const original = images.find((i) => i.id === id)
+    if (!original) return
+    const base = { ...original, ...localTransforms.current.get(id) }
     const updated =
       type === 'move'
         ? { ...base, x: x - offsetX, y: y - offsetY }
@@ -538,7 +538,6 @@ export default function InteractiveCanvas() {
 
   const clearCanvas = (broadcastChange = true) => {
     clearImages()
-    setDragImages(null)
     strokesRef.current = []
     const ctx = ctxRef.current
     if (ctx && drawingCanvasRef.current) {

--- a/liveblocks.config.ts
+++ b/liveblocks.config.ts
@@ -2,14 +2,18 @@
 // https://liveblocks.io/docs/api-reference/liveblocks-react#Typing-your-data
 import type { LiveMap, LiveObject, LiveList } from '@liveblocks/client'
 
+// Canvas images stored in Liveblocks. Keep in sync with components/canvas/ImageItem.tsx
+// but defined here to satisfy Liveblocks Lson constraints.
 type CanvasImage = {
-  id: number
-  src: string
+  id: string
+  url: string
   x: number
   y: number
   width: number
   height: number
-  local?: boolean
+  scale: number
+  rotation: number
+  createdAt: number
 }
 
 type SessionEvent = {
@@ -52,7 +56,7 @@ declare global {
     Storage: {
       characters: LiveMap<string, CharacterData>
       images: LiveMap<string, CanvasImage>
-        music: LiveObject<{ id: string; playing: boolean; volume: number }>
+      music: LiveObject<{ id: string; playing: boolean; volume: number }>
 
       summary: LiveObject<{ acts: LiveList<{ id: string; title: string }>; currentId?: string }>
       quickNote: LiveObject<{ text: string; updatedAt: number }>
@@ -72,7 +76,7 @@ declare global {
     RoomEvent:
       | { type: 'add-image'; image: CanvasImage }
       | { type: 'update-image'; image: CanvasImage }
-      | { type: 'delete-image'; id: number }
+      | { type: 'delete-image'; id: string }
       | { type: 'clear-canvas' }
       | {
           type: 'draw-line'


### PR DESCRIPTION
## Summary
- store uploaded canvas images directly in Liveblocks storage with metadata
- add optimistic placeholders and validation for image uploads
- throttle image drag updates and handle load errors

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b479058d44832ebda481b89751e5a3