### PR TITLE
Restore InteractiveCanvas and align Liveblocks storage types

### DIFF
--- a/app/Room.tsx
+++ b/app/Room.tsx
@@ -32,7 +32,8 @@ export function Room({
           images: new LiveMap(),
           strokes: new LiveList([]),
           music: new LiveObject({ id: '', playing: false, volume: 5 }),
-          summary: new LiveObject({ acts: [], currentId: '' }),
+          summary: new LiveObject({ acts: new LiveList([]), currentId: '' }),
+          quickNote: new LiveObject({ text: '', updatedAt: 0 }),
           editor: new LiveMap(),
           events: new LiveList([]),
           rooms: new LiveList([])

--- a/app/api/liveblocks-auth/route.ts
+++ b/app/api/liveblocks-auth/route.ts
@@ -3,15 +3,22 @@ export const runtime = "nodejs";
 import { Liveblocks } from '@liveblocks/node';
 import { randomUUID } from 'node:crypto';
 
-const liveblocks = new Liveblocks({
-  secret: process.env.LIVEBLOCKS_SECRET_KEY!,
-});
+const secret = process.env.LIVEBLOCKS_SECRET_KEY;
+
+if (!secret) {
+  console.warn('LIVEBLOCKS_SECRET_KEY is not set. Liveblocks auth endpoint will return 500.');
+}
 
 export async function POST(request: Request) {
   const { room } = await request.json();
   if (!room) {
     return new Response('Missing room id', { status: 400 });
   }
+  if (!secret) {
+    return new Response('Liveblocks secret key not configured', { status: 500 });
+  }
+
+  const liveblocks = new Liveblocks({ secret });
   const userId = randomUUID();
   const session = liveblocks.prepareSession(userId);
   session.allow(room, session.FULL_ACCESS);

--- a/components/canvas/InteractiveCanvas.tsx
+++ b/components/canvas/InteractiveCanvas.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useRef, useState, useEffect, useMemo, useCallback } from 'react'
+import { useRef, useState, useEffect, useReducer } from 'react'
 import {
+  useBroadcastEvent,
   useEventListener,
   useStorage,
   useMutation,
@@ -14,7 +15,17 @@ import CanvasTools, { ToolMode } from './CanvasTools'
 import { useT } from '@/lib/useT'
 import MusicPanel from './MusicPanel'
 import ImageItem, { ImageData } from './ImageItem'
-import SideNotes from '@/components/misc/SideNotes'\r\n\r\ntype StrokeSegment = {\r\n  id: string\r\n  x1: number\r\n  y1: number\r\n  x2: number\r\n  y2: number\r\n  color: string\r\n  width: number\r\n  mode: 'draw' | 'erase'\r\n}\r\n\r\nconst MIN_IMAGE_SIZE = 40\r\n\r\nconst clamp = (value: number, min: number, max: number) => {\r\n  if (Number.isNaN(value)) return min\r\n  if (max < min) return min\r\n  return Math.min(Math.max(value, min), max)\r\n}\r\n\r\nconst roundRatio = (value: number) => Math.round(value * 1000) / 1000\r\n\r\nconst normalizeImageRect = (img: ImageData, canvasWidth: number, canvasHeight: number): ImageData => {\r\n  if (!canvasWidth || !canvasHeight) {\r\n    return { ...img }\r\n  }\r\n  const width = clamp(img.width, MIN_IMAGE_SIZE, canvasWidth)\r\n  const height = clamp(img.height, MIN_IMAGE_SIZE, canvasHeight)\r\n  const x = clamp(img.x, 0, canvasWidth - width)\r\n  const y = clamp(img.y, 0, canvasHeight - height)\r\n\r\n  return {\r\n    ...img,\r\n    x,\r\n    y,\r\n    width,\r\n    height,\r\n    xRatio: roundRatio(x / canvasWidth),\r\n    yRatio: roundRatio(y / canvasHeight),\r\n    widthRatio: roundRatio(width / canvasWidth),\r\n    heightRatio: roundRatio(height / canvasHeight),\r\n  }\r\n}\r\n\r\nconst resolveImageRect = (img: ImageData, canvasWidth: number, canvasHeight: number): ImageData => {\r\n  if (!canvasWidth || !canvasHeight) {\r\n    return { ...img }\r\n  }\r\n\r\n  if (\r\n    img.xRatio === undefined ||\r\n    img.yRatio === undefined ||\r\n    img.widthRatio === undefined ||\r\n    img.heightRatio === undefined\r\n  ) {\r\n    const width = clamp(img.width, MIN_IMAGE_SIZE, canvasWidth)\r\n    const height = clamp(img.height, MIN_IMAGE_SIZE, canvasHeight)\r\n    const x = clamp(img.x, 0, canvasWidth - width)\r\n    const y = clamp(img.y, 0, canvasHeight - height)\r\n    return { ...img, x, y, width, height }\r\n  }\r\n\r\n  const width = clamp(img.widthRatio * canvasWidth, MIN_IMAGE_SIZE, canvasWidth)\r\n  const height = clamp(img.heightRatio * canvasHeight, MIN_IMAGE_SIZE, canvasHeight)\r\n  const x = clamp(img.xRatio * canvasWidth, 0, canvasWidth - width)\r\n  const y = clamp(img.yRatio * canvasHeight, 0, canvasHeight - height)\r\n\r\n  return {\r\n    ...img,\r\n    x,\r\n    y,\r\n    width,\r\n    height,\r\n  }\r\n}\r\n
+import SideNotes from '@/components/misc/SideNotes'
+
+interface StrokeSegment {
+  x1: number
+  y1: number
+  x2: number
+  y2: number
+  color: string
+  width: number
+  mode: ToolMode
+}
 
 export default function InteractiveCanvas() {
   // `images` map is created by RoomProvider but may be null until ready
@@ -22,35 +33,27 @@ export default function InteractiveCanvas() {
   const images = imagesMap
     ? (Array.from(imagesMap.values()) as ImageData[])
     : []
+  const [pendingImages, setPendingImages] = useState<ImageData[]>([])
+  const localTransforms = useRef<Map<string, Partial<ImageData>>>(new Map())
+  const [, forceRender] = useReducer((x: number) => x + 1, 0)
+  const rafPending = useRef(false)
+  const scheduleRender = () => {
+    if (rafPending.current) return
+    rafPending.current = true
+    requestAnimationFrame(() => {
+      rafPending.current = false
+      forceRender()
+    })
+  }
+  const imagesToRender = [
+    ...images.map((img) => {
+      const local = localTransforms.current.get(img.id)
+      return local ? { ...img, ...local } : img
+    }),
+    ...pendingImages,
+  ]
 
-  const strokesList = useStorage((root) => root.strokes)
-  const strokes = useMemo<StrokeSegment[]>(() => {
-    if (!strokesList) return []
-    const result: StrokeSegment[] = []
-
-  const displayImages = useMemo(() => {
-    if (!canvasSize.width || !canvasSize.height) {
-      return images.map((img) => ({ ...img }))
-    }
-    return images.map((img) => resolveImageRect(img, canvasSize.width, canvasSize.height))
-  }, [images, canvasSize])
-
-  const displayImageMap = useMemo(() => {
-    const map = new Map<number, ImageData>()
-    displayImages.forEach((img) => map.set(img.id, img))
-    return map
-  }, [displayImages])
-
-    for (let i = 0; i < strokesList.length; i += 1) {
-      const entry = strokesList.get(i)
-      if (entry) {
-        result.push(entry as StrokeSegment)
-      }
-    }
-    return result
-  }, [strokesList])
-
-  const musicObj = useStorage((root) => root.music) // peut ÃƒÆ’Ã‚Âªtre null au dÃƒÆ’Ã‚Â©marrage
+  const musicObj = useStorage((root) => root.music) // peut être null au démarrage
   const storageReady = Boolean(musicObj)
 
   const [isDrawing, setIsDrawing] = useState(false)
@@ -61,8 +64,7 @@ export default function InteractiveCanvas() {
   const brushSize = drawMode === 'erase' ? eraserSize : penSize
   const [mousePos, setMousePos] = useState({ x: 0, y: 0 })
   const [toolsVisible, setToolsVisible] = useState(false)
-  const [audioVisible, setAudioVisible] = useState(false)\r\n  const [pendingImages, setPendingImages] = useState<ImageData[]>([])
-  const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 })
+  const [audioVisible, setAudioVisible] = useState(false)
 
   const [ytUrl, setYtUrl] = useState('')
   const [ytId, setYtId] = useState('')
@@ -70,89 +72,27 @@ export default function InteractiveCanvas() {
   // Lecture: synchro globale
   const [isPlaying, setIsPlaying] = useState(false)
 
-  // Volume: gestion locale du volume (0..100), valeur par dÃ©faut 30%\r\n  const [volume, setVolumeState] = useState(30)\r\n  const setVolume = useCallback((value: number) => {\r\n    const clamped = Math.max(0, Math.min(100, Math.round(value)))\r\n    setVolumeState(clamped)\r\n    if (typeof window !== 'undefined') {\r\n      window.localStorage.setItem('canvas_volume', String(clamped))\r\n    }\r\n  }, [])
+  // Volume: synchro globale (0..100), défaut 5%
+  const [volume, setVolumeState] = useState(5)
+  const setVolume = (v: number) => {
+    setVolumeState(v)
+    if (storageReady) updateMusic({ volume: v })
+  }
 
-  const [, updateMyPresence] = useMyPresence()\r\n  const lastPointRef = useRef<{ x: number; y: number } | null>(null)\r\n
+  const broadcast = useBroadcastEvent()
+  const lastSend = useRef(0)
+  const THROTTLE = 0
+  const lastMutation = useRef(0)
+  const MUTATION_THROTTLE = 100
+  const [, updateMyPresence] = useMyPresence()
+
   const canvasRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (typeof window === "undefined") return
-    const stored = window.localStorage.getItem("canvas_volume")
-    if (!stored) return
-    const parsed = Number(stored)
-    if (Number.isFinite(parsed)) {
-      setVolumeState(Math.max(0, Math.min(100, Math.round(parsed))))
-    }
-  }, [])
-
   const drawingCanvasRef = useRef<HTMLCanvasElement>(null)
   const ctxRef = useRef<CanvasRenderingContext2D | null>(null)
   const playerRef = useRef<YouTubePlayer | null>(null)
   const t = useT()
   const initializedRef = useRef(false)
-
-  const createStrokeId = useCallback(() => {
-    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-      return crypto.randomUUID()
-    }
-    return `${Date.now()}-${Math.random().toString(36).slice(2)}`
-  }, [])
-
-  const redrawCanvas = useCallback(() => {
-    const canvas = drawingCanvasRef.current
-    const ctx = ctxRef.current
-    if (!canvas || !ctx) return
-
-    ctx.clearRect(0, 0, canvas.width, canvas.height)
-    ctx.beginPath()
-
-    strokes.forEach((segment) => {
-      ctx.save()
-      ctx.lineWidth = segment.width
-      ctx.strokeStyle = segment.mode === 'erase' ? 'rgba(0,0,0,1)' : segment.color
-      ctx.globalCompositeOperation =
-        segment.mode === 'erase' ? 'destination-out' : 'source-over'
-      ctx.beginPath()
-      ctx.moveTo(segment.x1, segment.y1)
-      ctx.lineTo(segment.x2, segment.y2)
-      ctx.stroke()
-      ctx.restore()
-    })
-
-    ctx.globalCompositeOperation = 'source-over'
-    ctx.beginPath()
-  }, [strokes])
-
-  useEffect(() => {
-    redrawCanvas()
-  }, [redrawCanvas])
-
-  useEffect(() => {
-    const resize = () => {
-      const canvas = drawingCanvasRef.current
-      if (!canvas) return
-
-      const rect = canvas.getBoundingClientRect()
-      const dpr = window.devicePixelRatio || 1
-      canvas.width = rect.width * dpr
-      canvas.height = rect.height * dpr
-      setCanvasSize((prev) => (prev.width === rect.width && prev.height === rect.height ? prev : { width: rect.width, height: rect.height }))
-
-      const ctx = canvas.getContext('2d')
-      if (ctx) {
-        ctx.scale(dpr, dpr)
-        ctx.lineCap = 'round'
-        ctx.lineJoin = 'round'
-        ctxRef.current = ctx
-      }
-
-      redrawCanvas()
-    }
-
-    resize()
-    window.addEventListener('resize', resize)
-    return () => window.removeEventListener('resize', resize)
-  }, [toolsVisible, audioVisible, redrawCanvas])
+  const strokesRef = useRef<StrokeSegment[]>([])
 
   useEffect(() => {
     return () => {
@@ -190,26 +130,59 @@ export default function InteractiveCanvas() {
     })
   }, [])
 
-  const addStrokeSegment = useMutation(({ storage }, segment: StrokeSegment) => {
-    storage.get('strokes').push(segment as StrokeSegment)
-  }, [])
+  const IMAGE_MIN_SIZE = 50
+  const ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/jpg', 'image/webp']
+  const MAX_SIZE_MB = 5
 
-  const clearStrokes = useMutation(({ storage }) => {
-    storage.get('strokes').clear()
-  }, [])
+  const clampImage = (img: ImageData, rect: DOMRect): ImageData => {
+    const width = Math.min(Math.max(img.width, IMAGE_MIN_SIZE), rect.width - img.x)
+    const height = Math.min(Math.max(img.height, IMAGE_MIN_SIZE), rect.height - img.y)
+    const x = Math.min(Math.max(img.x, 0), rect.width - width)
+    const y = Math.min(Math.max(img.y, 0), rect.height - height)
+    return { ...img, x, y, width, height }
+  }
 
-  // Mutation musique: gÃƒÆ’Ã‚Â¨re l'ÃƒÆ’Ã‚Â©tat global (id, lecture, volume)
+  const imagesRef = useRef<ImageData[]>([])
+  imagesRef.current = imagesToRender
+
+  // Mutation musique: gère l'état global (id, lecture, volume)
   const updateMusic = useMutation(
     (
       { storage },
-      updates: { id?: string; playing?: boolean },
+      updates: { id?: string; playing?: boolean; volume?: number },
     ) => {
       storage.get('music').update(updates)
     },
     [],
   )
 
-  // Events canvas (compatibilitÃƒÂ© avec les anciennes diffusions d''ÃƒÂ©vÃƒÂ©nements)\r\n  // eslint-disable-next-line @typescript-eslint/no-explicit-any\r\n  useEventListener((payload: any) => {\r\n    const { event } = payload\r\n    if (event.type === 'clear-canvas') {\r\n      clearCanvas()\r\n    } else if (event.type === 'draw-line') {\r\n      addStrokeSegment({\r\n        id: createStrokeId(),\r\n        x1: event.x1,\r\n        y1: event.y1,\r\n        x2: event.x2,\r\n        y2: event.y2,\r\n        color: event.color,\r\n        width: event.width,\r\n        mode: event.mode,\r\n      })\r\n    }\r\n  })
+  // Events canvas
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useEventListener((payload: any) => {
+    const { event } = payload
+    if (event.type === 'clear-canvas') {
+      clearCanvas(false)
+    } else if (event.type === 'draw-line' && ctxRef.current) {
+      const { x1, y1, x2, y2, color: c, width, mode } = event
+      ctxRef.current.strokeStyle = mode === 'erase' ? 'rgba(0,0,0,1)' : c
+      ctxRef.current.lineWidth = width
+      ctxRef.current.globalCompositeOperation =
+        mode === 'erase' ? 'destination-out' : 'source-over'
+      ctxRef.current.beginPath()
+      ctxRef.current.moveTo(x1, y1)
+      ctxRef.current.lineTo(x2, y2)
+      ctxRef.current.stroke()
+      strokesRef.current.push({
+        x1,
+        y1,
+        x2,
+        y2,
+        color: c,
+        width,
+        mode,
+      })
+    }
+  })
 
   const dragState = useRef({
     id: null as string | null,
@@ -238,7 +211,28 @@ export default function InteractiveCanvas() {
     }
   }
 
-
+  useEffect(() => {
+    const resize = () => {
+      const canvas = drawingCanvasRef.current
+      if (canvas) {
+        const rect = canvas.getBoundingClientRect()
+        const dpr = window.devicePixelRatio || 1
+        canvas.width = rect.width * dpr
+        canvas.height = rect.height * dpr
+        const ctx = canvas.getContext('2d')
+        if (ctx) {
+          ctx.scale(dpr, dpr)
+          ctx.lineCap = 'round'
+          ctx.lineJoin = 'round'
+          ctxRef.current = ctx
+          redrawStrokes()
+        }
+      }
+    }
+    resize()
+    window.addEventListener('resize', resize)
+    return () => window.removeEventListener('resize', resize)
+  }, [])
 
   useEffect(() => {
     const canvas = drawingCanvasRef.current
@@ -286,7 +280,7 @@ export default function InteractiveCanvas() {
     }
   }, [volume])
 
-  // Lecture: contrÃƒÆ’Ã‚Â´le global (synchro via musicObj)
+  // Lecture: contrôle global (synchro via musicObj)
   useEffect(() => {
     const player = playerRef.current
     if (!player) return
@@ -294,14 +288,15 @@ export default function InteractiveCanvas() {
     else player.pauseVideo()
   }, [isPlaying])
 
-  // Quand lÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã‚Â©tat global musique change (depuis Liveblocks), on sÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢aligne
+  // Quand l’état global musique change (depuis Liveblocks), on s’aligne
   useEffect(() => {
     if (!musicObj) return
     setYtId(musicObj.id)
     setIsPlaying(!!musicObj.playing)
+    setVolumeState(musicObj.volume ?? 5)
   }, [musicObj])
 
-  // --------- DnD images: aperÃƒÆ’Ã‚Â§u instantanÃƒÆ’Ã‚Â© + swap vers Cloudinary optimisÃƒÆ’Ã‚Â© ---------
+  // --------- DnD images: aperçu instantané + swap vers Cloudinary optimisé ---------
 
   function fileToObjectURL(file: File) {
     return URL.createObjectURL(file)
@@ -318,17 +313,22 @@ export default function InteractiveCanvas() {
       return
     }
     const localUrl = fileToObjectURL(file)
-    const tempId = Date.now() + Math.random()
-    const baseImg: ImageData = {
-      id: tempId,
-      src: localUrl,
-      x: dropX - 100,
-      y: dropY - 100,
-      width: 200,
-      height: 200,
-    }
-    setPendingImages((prev) => [...prev, baseImg])
-
+    const id = crypto.randomUUID()
+    const tempImg: ImageData = clampImage(
+      {
+        id,
+        url: localUrl,
+        x: dropX - 100,
+        y: dropY - 100,
+        width: 200,
+        height: 200,
+        scale: 1,
+        rotation: 0,
+        createdAt: Date.now(),
+      },
+      rect,
+    )
+    setPendingImages((prev) => [...prev, tempImg])
     try {
       const form = new FormData()
       form.append('file', file)
@@ -342,13 +342,26 @@ export default function InteractiveCanvas() {
       if (!finalUrl) {
         throw new Error('No URL returned by Cloudinary endpoint')
       }
-
-      addImage({ ...baseImg, src: finalUrl })
+      const width: number = data.width ?? tempImg.width
+      const height: number = data.height ?? tempImg.height
+      const finalImg: ImageData = clampImage(
+        {
+          ...tempImg,
+          url: finalUrl,
+          x: dropX - width / 2,
+          y: dropY - height / 2,
+          width,
+          height,
+          createdAt: Date.now(),
+        },
+        rect,
+      )
+      addImage(finalImg)
     } catch (err) {
       console.error(err)
       alert('Image upload failed')
     } finally {
-      setPendingImages((prev) => prev.filter((img) => img.id !== tempId))
+      setPendingImages((prev) => prev.filter((i) => i.id !== id))
       URL.revokeObjectURL(localUrl)
     }
   }
@@ -395,7 +408,9 @@ export default function InteractiveCanvas() {
         ctx.globalCompositeOperation =
           drawMode === 'erase' ? 'destination-out' : 'source-over'
         ctx.beginPath()
-        ctx.moveTo(x, y)\r\n      }\r\n      lastPointRef.current = { x, y }\r\n      return
+        ctx.moveTo(x, y)
+      }
+      return
     }
 
     if (drawMode === 'images' && id && type) {
@@ -437,7 +452,41 @@ export default function InteractiveCanvas() {
       setIsDrawing(false)
     }
 
-    if (\r\n      isDrawing &&\r\n      (drawMode === 'draw' || drawMode === 'erase') &&\r\n      ctxRef.current\r\n    ) {\r\n      const previous = lastPointRef.current\r\n      ctxRef.current.lineTo(x, y)\r\n      ctxRef.current.stroke()\r\n      if (!previous || previous.x !== x || previous.y !== y) {\r\n        addStrokeSegment({\r\n          id: createStrokeId(),\r\n          x1: previous?.x ?? x,\r\n          y1: previous?.y ?? y,\r\n          x2: x,\r\n          y2: y,\r\n          color,\r\n          width: brushSize,\r\n          mode: drawMode,\r\n        })\r\n      }\r\n      lastPointRef.current = { x, y }\r\n    }\r\n
+    if (
+      isDrawing &&
+      (drawMode === 'draw' || drawMode === 'erase') &&
+      ctxRef.current &&
+      e.buttons === 1
+    ) {
+      ctxRef.current.lineTo(x, y)
+      ctxRef.current.stroke()
+      strokesRef.current.push({
+        x1: prev.x,
+        y1: prev.y,
+        x2: x,
+        y2: y,
+        color,
+        width: brushSize,
+        mode: drawMode,
+      })
+      const now = Date.now()
+      if (THROTTLE === 0 || now - lastSend.current > THROTTLE) {
+        lastSend.current = now
+        broadcast({
+          type: 'draw-line',
+          x1: prev.x,
+          y1: prev.y,
+          x2: x,
+          y2: y,
+          color,
+          width: brushSize,
+          mode: drawMode,
+        } as Liveblocks['RoomEvent'])
+      }
+    } else if (isDrawing && e.buttons !== 1) {
+      setIsDrawing(false)
+    }
+
     const { id, type, offsetX, offsetY } = dragState.current
     if (!id || !type) return
     const original = images.find((i) => i.id === id)
@@ -457,9 +506,22 @@ export default function InteractiveCanvas() {
     }
   }
 
-  const handlePointerUp = () => {\r\n    setIsDrawing(false)\r\n    lastPointRef.current = null\r\n    dragState.current = { id: null, type: null, offsetX: 0, offsetY: 0 }\r\n  }
+  const handlePointerUp = () => {
+    setIsDrawing(false)
+    const { id } = dragState.current
+    if (id) {
+      const local = localTransforms.current.get(id)
+      if (local) updateImageTransform(id, local)
+      localTransforms.current.delete(id)
+      scheduleRender()
+    }
+    dragState.current = { id: null, type: null, offsetX: 0, offsetY: 0 }
+  }
 
-  const handlePointerLeave = () => {\r\n    lastPointRef.current = null\r\n    updateMyPresence({ cursor: null })\r\n  }
+  const handlePointerLeave = () => {
+    updateMyPresence({ cursor: null })
+    if (dragState.current.id) handlePointerUp()
+  }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (drawMode !== 'images' || selectedImageId === null) return
@@ -481,7 +543,22 @@ export default function InteractiveCanvas() {
     }
   }
 
-  const clearCanvas = () => {\r\n    clearImages()\r\n    clearStrokes()\r\n    setPendingImages([])\r\n    const ctx = ctxRef.current\r\n    if (ctx && drawingCanvasRef.current) {\r\n      ctx.clearRect(\r\n        0,\r\n        0,\r\n        drawingCanvasRef.current.width,\r\n        drawingCanvasRef.current.height,\r\n      )\r\n      ctx.beginPath()\r\n    }\r\n  }
+  const clearCanvas = (broadcastChange = true) => {
+    clearImages()
+    strokesRef.current = []
+    const ctx = ctxRef.current
+    if (ctx && drawingCanvasRef.current) {
+      ctx.clearRect(
+        0,
+        0,
+        drawingCanvasRef.current.width,
+        drawingCanvasRef.current.height,
+      )
+    }
+    if (broadcastChange) {
+      broadcast({ type: 'clear-canvas' } as Liveblocks['RoomEvent'])
+    }
+  }
 
   const handleDeleteImage = (id: string) => {
     removeImage(id)
@@ -495,7 +572,7 @@ export default function InteractiveCanvas() {
   const handleYtSubmit = () => {
     const match = ytUrl.match(/(?:youtube\.com.*v=|youtu\.be\/)([^&\n?#]+)/)
     if (match) {
-      setYtId(match[1] ?? '') // local immÃƒÆ’Ã‚Â©diat
+      setYtId(match[1] ?? '') // local immédiat
       setIsPlaying(true)
       if (storageReady) {
         updateMusic({ id: match[1], playing: true })
@@ -525,7 +602,7 @@ export default function InteractiveCanvas() {
             onClick={() => setToolsVisible(!toolsVisible)}
             className="rounded-xl px-5 py-2 text-base font-semibold shadow border-none bg-black/30 text-white/90 hover:bg-emerald-600 hover:text-white transition duration-100 flex items-center justify-center min-h-[38px]"
           >
-            <span className="mr-1">ÃƒÂ°Ã…Â¸Ã¢â‚¬ÂºÃ‚Â ÃƒÂ¯Ã‚Â¸Ã‚Â</span>{' '}
+            <span className="mr-1">🛠️</span>{' '}
             <span className="text-sm">{toolsVisible ? t('tools') : ''}</span>
           </button>
         </div>
@@ -552,7 +629,7 @@ export default function InteractiveCanvas() {
             {isPlaying && (
               <span className="absolute inset-0 rounded-xl pointer-events-none animate-pulse-ring" />
             )}
-            <span className="relative">ÃƒÂ°Ã…Â¸Ã…Â½Ã‚Âµ</span>
+            <span className="relative">🎵</span>
           </button>
         </div>
         {audioVisible && (
@@ -566,7 +643,7 @@ export default function InteractiveCanvas() {
             setVolume={setVolume}
           />
         )}
-        {/* Player YouTube (toujours montÃƒÆ’Ã‚Â© pour conserver la lecture) */}
+        {/* Player YouTube (toujours monté pour conserver la lecture) */}
         {ytId && (
           <YouTube
             videoId={ytId}
@@ -606,21 +683,7 @@ export default function InteractiveCanvas() {
             className="absolute top-0 left-0 w-full h-full"
           />
 
-          {pendingImages.map((img) => (
-            <div
-              key={`pending-${img.id}`}
-              className="absolute rounded-2xl border border-dashed border-white/30 bg-black/30 pointer-events-none animate-pulse"
-              style={{ top: img.y, left: img.x, width: img.width, height: img.height, zIndex: 2 }}
-            >
-              <img
-                src={img.src}
-                alt="Envoi en cours"
-                className="w-full h-full object-contain rounded-2xl opacity-80"
-              />
-            </div>
-          ))}
-
-          {images.map((img) => (
+          {imagesToRender.map((img) => (
             <ImageItem
               key={img.id}
               img={img}
@@ -649,9 +712,9 @@ export default function InteractiveCanvas() {
           <LiveCursors />
           <SideNotes />
 
-          {/* DiceHub supprimÃƒÆ’Ã‚Â© : les lancers de dÃƒÆ’Ã‚Â©s ne sont plus synchronisÃƒÆ’Ã‚Â©s globalement */}
+          {/* DiceHub supprimé : les lancers de dés ne sont plus synchronisés globalement */}
         </div>{' '}
-        {/* ÃƒÂ¢Ã¢â‚¬Â Ã‚Â fin du conteneur relatif */}
+        {/* ← fin du conteneur relatif */}
       </div>
 
       <style jsx>{`
@@ -673,32 +736,3 @@ export default function InteractiveCanvas() {
     </>
   )
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/components/rooms/RoomAvatarStack.tsx
+++ b/components/rooms/RoomAvatarStack.tsx
@@ -12,8 +12,8 @@ export default function RoomAvatarStack({ id }: { id: string }) {
         initialStorage={{
           characters: new LiveMap(),
           images: new LiveMap(),
-            music: new LiveObject({ id: '', playing: false, volume: 5 }),
-
+          strokes: new LiveList([]),
+          music: new LiveObject({ id: '', playing: false, volume: 5 }),
           summary: new LiveObject({ acts: new LiveList<{ id: string; title: string }>([]) }),
           quickNote: new LiveObject({ text: '', updatedAt: 0 }),
 

--- a/liveblocks.config.ts
+++ b/liveblocks.config.ts
@@ -67,7 +67,11 @@ declare global {
       images: LiveMap<string, CanvasImage>
       strokes: LiveList<StrokeSegment>
       music: LiveObject<{ id: string; playing: boolean; volume?: number }>
-      summary: LiveObject<{ acts: Array<{ id: string; title: string }> }>
+      summary: LiveObject<{
+        acts: LiveList<{ id: string; title: string }>
+        currentId?: string
+      }>
+      quickNote: LiveObject<{ text: string; updatedAt: number }>
       editor: LiveMap<string, string>
       events: LiveList<SessionEvent>
       rooms: LiveList<Room>


### PR DESCRIPTION
## Summary
- restore the working InteractiveCanvas implementation to remove the corrupted text and reinstate collaborative drawing behaviour
- align Liveblocks storage typing and initial storage values (summary uses LiveList, quickNote added) across the config, Room provider, and avatar stack helper
- guard the Liveblocks auth route so builds succeed when the secret key is not configured

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e27f4ae31c832e98fbc36885a414c0