### PR TITLE
Fix duplicated content in InteractiveCanvas

### DIFF
--- a/components/canvas/InteractiveCanvas.tsx
+++ b/components/canvas/InteractiveCanvas.tsx
@@ -1,14 +1,12 @@
-"use client"
+﻿'use client'
 
-import { useRef, useState, useEffect, useReducer, useMemo, useCallback } from 'react'
+import { useRef, useState, useEffect, useMemo, useCallback } from 'react'
 import {
-  useBroadcastEvent,
   useEventListener,
   useStorage,
   useMutation,
   useMyPresence,
 } from '@liveblocks/react'
-import type { LiveList } from '@liveblocks/client'
 import type { LiveList } from '@liveblocks/client'
 import LiveCursors from './LiveCursors'
 import YouTube from 'react-youtube'
@@ -111,14 +109,7 @@ export default function InteractiveCanvas() {
     if (!imagesMap) return [] as ImageData[]
     return Array.from(imagesMap.values()) as ImageData[]
   }, [imagesMap])
-  const images = useMemo(() => {
-    if (!imagesMap) return [] as ImageData[]
-    return Array.from(imagesMap.values()) as ImageData[]
-  }, [imagesMap])
 
-  const strokesList = useStorage((root) => root.strokes) as
-    | LiveList<StrokeSegment>
-    | null
   const strokesList = useStorage((root) => root.strokes) as
     | LiveList<StrokeSegment>
     | null
@@ -130,22 +121,13 @@ export default function InteractiveCanvas() {
     const fallback = [] as StrokeSegment[]
     for (let i = 0; i < (strokesList as LiveList<StrokeSegment>).length; i += 1) {
       const entry = (strokesList as LiveList<StrokeSegment>).get(i)
-    if (typeof (strokesList as LiveList<StrokeSegment>).toArray === 'function') {
-      return (strokesList as LiveList<StrokeSegment>).toArray()
-    }
-    const fallback = [] as StrokeSegment[]
-    for (let i = 0; i < (strokesList as LiveList<StrokeSegment>).length; i += 1) {
-      const entry = (strokesList as LiveList<StrokeSegment>).get(i)
       if (entry) {
-        fallback.push(entry as StrokeSegment)
         fallback.push(entry as StrokeSegment)
       }
     }
     return fallback
-    return fallback
   }, [strokesList])
 
-  const musicObj = useStorage((root) => root.music) // peut tre null au dmarrage
   const musicObj = useStorage((root) => root.music) // peut tre null au dmarrage
   const storageReady = Boolean(musicObj)
 
@@ -159,15 +141,7 @@ export default function InteractiveCanvas() {
   const [toolsVisible, setToolsVisible] = useState(false)
   const [audioVisible, setAudioVisible] = useState(false)
   const [pendingImages, setPendingImages] = useState<ImageData[]>([])
-  const [audioVisible, setAudioVisible] = useState(false)
-  const [pendingImages, setPendingImages] = useState<ImageData[]>([])
   const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 })
-
-  const [renderVersion, setRenderVersion] = useState(0)
-  const imagesRef = useRef<ImageData[]>([])
-  const localTransforms = useRef(new Map<string, Partial<ImageData>>())
-  const renderFrame = useRef<number | null>(null)
-  const lastMutation = useRef(0)
 
   const [renderVersion, setRenderVersion] = useState(0)
   const imagesRef = useRef<ImageData[]>([])
@@ -190,32 +164,11 @@ export default function InteractiveCanvas() {
       window.localStorage.setItem('canvas_volume', String(clamped))
     }
   }, [])
-  // Volume: gestion locale du volume (0..100), valeur par dfaut 30%
-  const [volume, setVolumeState] = useState(30)
-  const setVolume = useCallback((value: number) => {
-    const clamped = Math.max(0, Math.min(100, Math.round(value)))
-    setVolumeState(clamped)
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('canvas_volume', String(clamped))
-    }
-  }, [])
-
-  const [, updateMyPresence] = useMyPresence()
-  const lastPointRef = useRef<{ x: number; y: number } | null>(null)
 
   const [, updateMyPresence] = useMyPresence()
   const lastPointRef = useRef<{ x: number; y: number } | null>(null)
 
   const canvasRef = useRef<HTMLDivElement>(null)
-
-  const scheduleRender = useCallback(() => {
-    if (renderFrame.current) cancelAnimationFrame(renderFrame.current)
-    renderFrame.current = requestAnimationFrame(() => {
-      renderFrame.current = null
-      setRenderVersion((v) => v + 1)
-    })
-  }, [])
-
 
   const scheduleRender = useCallback(() => {
     if (renderFrame.current) cancelAnimationFrame(renderFrame.current)
@@ -282,58 +235,11 @@ export default function InteractiveCanvas() {
     if (changed) scheduleRender()
   }, [images, scheduleRender])
 
-
-  useEffect(() => () => {
-    if (renderFrame.current) cancelAnimationFrame(renderFrame.current)
-  }, [])
-
-  const storedImageMap = useMemo(() => {
-    const map = new Map<string, ImageData>()
-    images.forEach((img) => map.set(String(img.id), img))
-    return map
-  }, [images])
-
-  const imagesToRender = useMemo(() => {
-    void renderVersion
-    return images.map((img) => {
-      const key = String(img.id)
-      const overrides = localTransforms.current.get(key)
-      const merged = overrides ? { ...img, ...overrides } : img
-      return resolveImageRect(
-        merged as ImageData,
-        canvasSize.width,
-        canvasSize.height,
-      )
-    })
-  }, [images, canvasSize, renderVersion])
-
-  imagesRef.current = imagesToRender
-
-  const renderedImageMap = useMemo(() => {
-    const map = new Map<string, ImageData>()
-    imagesToRender.forEach((img) => map.set(String(img.id), img))
-    return map
-  }, [imagesToRender])
-
-  useEffect(() => {
-    const ids = new Set(images.map((img) => String(img.id)))
-    const transforms = localTransforms.current
-    let changed = false
-    for (const key of Array.from(transforms.keys())) {
-      if (!ids.has(key)) {
-        transforms.delete(key)
-        changed = true
-      }
-    }
-    if (changed) scheduleRender()
-  }, [images, scheduleRender])
-
   const drawingCanvasRef = useRef<HTMLCanvasElement>(null)
   const ctxRef = useRef<CanvasRenderingContext2D | null>(null)
   const playerRef = useRef<YouTubePlayer | null>(null)
   const t = useT()
   const initializedRef = useRef(false)
-  const strokesRef = useRef<StrokeSegment[]>([])
   const strokesRef = useRef<StrokeSegment[]>([])
 
   useEffect(() => {
@@ -380,46 +286,7 @@ export default function InteractiveCanvas() {
     strokesRef.current = []
   }, [])
 
-  useEffect(() => {
-    strokesRef.current = strokes
-  }, [strokes])
-
-  const addStrokeSegment = useMutation(
-    ({ storage }, segment: StrokeSegment) => {
-      const list = storage.get('strokes') as LiveList<StrokeSegment> | null
-      if (!list) return
-      if (typeof list.push === 'function') {
-        list.push(segment)
-      } else if (typeof (list as unknown as { insert?: (index: number, value: StrokeSegment) => void }).insert === 'function') {
-        const helper = list as unknown as {
-          insert: (index: number, value: StrokeSegment) => void
-          length?: number
-        }
-        helper.insert((helper.length ?? 0) as number, segment)
-      }
-      strokesRef.current = [...strokesRef.current, segment]
-    },
-    [strokesRef],
-  )
-
-  const clearStrokes = useMutation(({ storage }) => {
-    const list = storage.get('strokes') as LiveList<StrokeSegment> | null
-    if (!list) {
-      strokesRef.current = []
-      return
-    }
-    if (typeof list.clear === 'function') {
-      list.clear()
-    } else if (typeof list.delete === 'function') {
-      for (let i = (list.length ?? 0) - 1; i >= 0; i -= 1) {
-        list.delete(i)
-      }
-    }
-    strokesRef.current = []
-  }, [])
-
   const addImage = useMutation(({ storage }, img: ImageData) => {
-    storage.get('images').set(String(img.id), img)
     storage.get('images').set(String(img.id), img)
   }, [])
 
@@ -439,7 +306,6 @@ export default function InteractiveCanvas() {
   )
 
   const removeImage = useMutation(({ storage }, id: string) => {
-    storage.get('images').delete(String(id))
     storage.get('images').delete(String(id))
   }, [])
 
@@ -486,49 +352,11 @@ export default function InteractiveCanvas() {
       }
     })
   }, [images, updateImageTransform])
-  const IMAGE_MIN_SIZE = 50
-  const ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/jpg', 'image/webp']
-  const MAX_SIZE_MB = 5
 
-  const clampImage = (img: ImageData, rect: DOMRect): ImageData => {
-    const width = Math.min(Math.max(img.width, IMAGE_MIN_SIZE), rect.width - img.x)
-    const height = Math.min(Math.max(img.height, IMAGE_MIN_SIZE), rect.height - img.y)
-    const x = Math.min(Math.max(img.x, 0), rect.width - width)
-    const y = Math.min(Math.max(img.y, 0), rect.height - height)
-    return { ...img, x, y, width, height }
-  }
-
-  useEffect(() => {
-    const rect = drawingCanvasRef.current?.getBoundingClientRect()
-    if (!rect) return
-    images.forEach((img) => {
-      if (
-        img.xRatio === undefined ||
-        img.yRatio === undefined ||
-        img.widthRatio === undefined ||
-        img.heightRatio === undefined
-      ) {
-        const normalized = normalizeImageRect(img, rect.width, rect.height)
-        updateImageTransform(String(img.id), {
-          x: normalized.x,
-          y: normalized.y,
-          width: normalized.width,
-          height: normalized.height,
-          xRatio: normalized.xRatio,
-          yRatio: normalized.yRatio,
-          widthRatio: normalized.widthRatio,
-          heightRatio: normalized.heightRatio,
-        })
-      }
-    })
-  }, [images, updateImageTransform])
-
-  // Mutation musique: gre l'tat global (id, lecture, volume)
   // Mutation musique: gre l'tat global (id, lecture, volume)
   const updateMusic = useMutation(
     (
       { storage },
-      updates: { id?: string; playing?: boolean; volume?: number },
       updates: { id?: string; playing?: boolean; volume?: number },
     ) => {
       storage.get('music').update(updates)
@@ -536,25 +364,6 @@ export default function InteractiveCanvas() {
     [],
   )
 
-  // Events canvas (compatibilit avec les anciennes diffusions d''vnements)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  useEventListener((payload: any) => {
-    const { event } = payload
-    if (event.type === 'clear-canvas') {
-      clearCanvas()
-    } else if (event.type === 'draw-line') {
-      addStrokeSegment({
-        id: createStrokeId(),
-        x1: event.x1,
-        y1: event.y1,
-        x2: event.x2,
-        y2: event.y2,
-        color: event.color,
-        width: event.width,
-        mode: event.mode,
-      })
-    }
-  })
   // Events canvas (compatibilit avec les anciennes diffusions d''vnements)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   useEventListener((payload: any) => {
@@ -601,27 +410,7 @@ export default function InteractiveCanvas() {
       if (!rect) return
       const map = new Map<string, ImageData>()
       images.forEach((img) => map.set(String(img.id), img))
-      const map = new Map<string, ImageData>()
-      images.forEach((img) => map.set(String(img.id), img))
       imagesRef.current.forEach((img) => {
-        const key = String(img.id)
-        const stored = map.get(key)
-        if (!stored) return
-        const normalized = normalizeImageRect(
-          { ...stored, ...img },
-          rect.width,
-          rect.height,
-        )
-        updateImageTransform(key, {
-          x: normalized.x,
-          y: normalized.y,
-          width: normalized.width,
-          height: normalized.height,
-          xRatio: normalized.xRatio,
-          yRatio: normalized.yRatio,
-          widthRatio: normalized.widthRatio,
-          heightRatio: normalized.heightRatio,
-        })
         const key = String(img.id)
         const stored = map.get(key)
         if (!stored) return
@@ -649,7 +438,6 @@ export default function InteractiveCanvas() {
       window.removeEventListener('orientationchange', handleResize)
     }
   }, [images, updateImageTransform])
-  }, [images, updateImageTransform])
 
   useEffect(() => {
     if (drawMode === 'erase') {
@@ -667,7 +455,6 @@ export default function InteractiveCanvas() {
   }, [volume])
 
   // Lecture: contrle global (synchro via musicObj)
-  // Lecture: contrle global (synchro via musicObj)
   useEffect(() => {
     const player = playerRef.current
     if (!player) return
@@ -676,16 +463,13 @@ export default function InteractiveCanvas() {
   }, [isPlaying])
 
   // Quand ltat global musique change (depuis Liveblocks), on saligne
-  // Quand ltat global musique change (depuis Liveblocks), on saligne
   useEffect(() => {
     if (!musicObj) return
     setYtId(musicObj.id)
     setIsPlaying(!!musicObj.playing)
     setVolumeState(musicObj.volume ?? 5)
-    setVolumeState(musicObj.volume ?? 5)
   }, [musicObj])
 
-  // --------- DnD images: aperu instantan + swap vers Cloudinary optimis ---------
   // --------- DnD images: aperu instantan + swap vers Cloudinary optimis ---------
 
   function fileToObjectURL(file: File) {
@@ -704,10 +488,8 @@ export default function InteractiveCanvas() {
     }
     const localUrl = fileToObjectURL(file)
     const tempId = `${Date.now()}-${Math.random().toString(36).slice(2)}`
-    const tempId = `${Date.now()}-${Math.random().toString(36).slice(2)}`
     const baseImg: ImageData = {
       id: tempId,
-      url: localUrl,
       url: localUrl,
       x: dropX - 100,
       y: dropY - 100,
@@ -736,17 +518,10 @@ export default function InteractiveCanvas() {
         rect.height,
       )
       addImage(normalized)
-      const normalized = normalizeImageRect(
-        { ...baseImg, url: finalUrl, createdAt: Date.now() },
-        rect.width,
-        rect.height,
-      )
-      addImage(normalized)
     } catch (err) {
       console.error(err)
       alert('Image upload failed')
     } finally {
-      setPendingImages((prev) => prev.filter((i) => i.id !== tempId))
       setPendingImages((prev) => prev.filter((i) => i.id !== tempId))
       URL.revokeObjectURL(localUrl)
     }
@@ -797,27 +572,19 @@ export default function InteractiveCanvas() {
       }
       lastPointRef.current = { x, y }
       return
-        ctx.moveTo(x, y)
-      }
-      lastPointRef.current = { x, y }
-      return
     }
 
     if (drawMode === 'images' && id && type) {
-      const key = String(id)
-      const img = renderedImageMap.get(key)
       const key = String(id)
       const img = renderedImageMap.get(key)
       if (!img) return
 
       dragState.current = {
         id: key,
-        id: key,
         type,
         offsetX: e.clientX - rect.left - img.x,
         offsetY: e.clientY - rect.top - img.y,
       }
-      localTransforms.current.set(key, {
       localTransforms.current.set(key, {
         x: img.x,
         y: img.y,
@@ -825,7 +592,6 @@ export default function InteractiveCanvas() {
         height: img.height,
       })
       scheduleRender()
-      setSelectedImageId(key)
       setSelectedImageId(key)
     }
   }
@@ -865,42 +631,8 @@ export default function InteractiveCanvas() {
       lastPointRef.current = { x, y }
     }
 
-    if (
-      isDrawing &&
-      (drawMode === 'draw' || drawMode === 'erase') &&
-      ctxRef.current
-    ) {
-      const previous = lastPointRef.current
-      ctxRef.current.lineTo(x, y)
-      ctxRef.current.stroke()
-      if (!previous || previous.x !== x || previous.y !== y) {
-        addStrokeSegment({
-          id: createStrokeId(),
-          x1: previous?.x ?? x,
-          y1: previous?.y ?? y,
-          x2: x,
-          y2: y,
-          color,
-          width: brushSize,
-          mode: drawMode,
-        })
-      }
-      lastPointRef.current = { x, y }
-    }
-
     const { id, type, offsetX, offsetY } = dragState.current
     if (!id || !type) return
-    const stored = storedImageMap.get(id)
-    const baseSource =
-      localTransforms.current.get(id) ?? renderedImageMap.get(id)
-    if (!stored || !baseSource) return
-    const base = {
-      ...baseSource,
-      x: baseSource.x ?? stored.x ?? 0,
-      y: baseSource.y ?? stored.y ?? 0,
-      width: baseSource.width ?? stored.width ?? MIN_IMAGE_SIZE,
-      height: baseSource.height ?? stored.height ?? MIN_IMAGE_SIZE,
-    }
     const stored = storedImageMap.get(id)
     const baseSource =
       localTransforms.current.get(id) ?? renderedImageMap.get(id)
@@ -937,56 +669,9 @@ export default function InteractiveCanvas() {
         widthRatio: normalized.widthRatio,
         heightRatio: normalized.heightRatio,
       })
-      const normalized = normalizeImageRect(
-        { ...stored, ...clamped },
-        rect.width,
-        rect.height,
-      )
-      updateImageTransform(id, {
-        x: normalized.x,
-        y: normalized.y,
-        width: normalized.width,
-        height: normalized.height,
-        xRatio: normalized.xRatio,
-        yRatio: normalized.yRatio,
-        widthRatio: normalized.widthRatio,
-        heightRatio: normalized.heightRatio,
-      })
     }
   }
 
-  const handlePointerUp = () => {
-    setIsDrawing(false)
-    const { id } = dragState.current
-    lastPointRef.current = null
-    dragState.current = { id: null, type: null, offsetX: 0, offsetY: 0 }
-    if (!id) return
-    const rect = drawingCanvasRef.current?.getBoundingClientRect()
-    if (!rect) return
-    const stored = storedImageMap.get(id)
-    const override = localTransforms.current.get(id)
-    if (!stored || !override) return
-    const normalized = normalizeImageRect(
-      { ...stored, ...override },
-      rect.width,
-      rect.height,
-    )
-    updateImageTransform(id, {
-      x: normalized.x,
-      y: normalized.y,
-      width: normalized.width,
-      height: normalized.height,
-      xRatio: normalized.xRatio,
-      yRatio: normalized.yRatio,
-      widthRatio: normalized.widthRatio,
-      heightRatio: normalized.heightRatio,
-    })
-  }
-
-  const handlePointerLeave = () => {
-    lastPointRef.current = null
-    updateMyPresence({ cursor: null })
-  }
   const handlePointerUp = () => {
     setIsDrawing(false)
     const { id } = dragState.current
@@ -1023,7 +708,6 @@ export default function InteractiveCanvas() {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (drawMode !== 'images' || selectedImageId === null) return
     const img = renderedImageMap.get(selectedImageId)
-    const img = renderedImageMap.get(selectedImageId)
     const rect = drawingCanvasRef.current?.getBoundingClientRect()
     if (!img || !rect) return
     const step = 5
@@ -1035,7 +719,6 @@ export default function InteractiveCanvas() {
     updated = clampImage(updated, rect)
     if (updated.x !== img.x || updated.y !== img.y) {
       e.preventDefault()
-      localTransforms.current.set(selectedImageId, updated)
       localTransforms.current.set(selectedImageId, updated)
       scheduleRender()
       const stored = storedImageMap.get(selectedImageId)
@@ -1057,42 +740,8 @@ export default function InteractiveCanvas() {
         })
       }
     }
-      const stored = storedImageMap.get(selectedImageId)
-      if (stored) {
-        const normalized = normalizeImageRect(
-          { ...stored, ...updated },
-          rect.width,
-          rect.height,
-        )
-        updateImageTransform(selectedImageId, {
-          x: normalized.x,
-          y: normalized.y,
-          width: normalized.width,
-          height: normalized.height,
-          xRatio: normalized.xRatio,
-          yRatio: normalized.yRatio,
-          widthRatio: normalized.widthRatio,
-          heightRatio: normalized.heightRatio,
-        })
-      }
-    }
   }
 
-  const clearCanvas = () => {
-    clearImages()
-    clearStrokes()
-    setPendingImages([])
-    const ctx = ctxRef.current
-    if (ctx && drawingCanvasRef.current) {
-      ctx.clearRect(
-        0,
-        0,
-        drawingCanvasRef.current.width,
-        drawingCanvasRef.current.height,
-      )
-      ctx.beginPath()
-    }
-  }
   const clearCanvas = () => {
     clearImages()
     clearStrokes()
@@ -1111,7 +760,6 @@ export default function InteractiveCanvas() {
 
   const handleDeleteImage = (id: string) => {
     localTransforms.current.delete(String(id))
-    localTransforms.current.delete(String(id))
     removeImage(id)
   }
 
@@ -1123,7 +771,6 @@ export default function InteractiveCanvas() {
   const handleYtSubmit = () => {
     const match = ytUrl.match(/(?:youtube\.com.*v=|youtu\.be\/)([^&\n?#]+)/)
     if (match) {
-      setYtId(match[1] ?? '') // local immdiat
       setYtId(match[1] ?? '') // local immdiat
       setIsPlaying(true)
       if (storageReady) {
@@ -1155,7 +802,6 @@ export default function InteractiveCanvas() {
             className="rounded-xl px-5 py-2 text-base font-semibold shadow border-none bg-black/30 text-white/90 hover:bg-emerald-600 hover:text-white transition duration-100 flex items-center justify-center min-h-[38px]"
           >
             <span className="mr-1"></span>{' '}
-            <span className="mr-1"></span>{' '}
             <span className="text-sm">{toolsVisible ? t('tools') : ''}</span>
           </button>
         </div>
@@ -1183,7 +829,6 @@ export default function InteractiveCanvas() {
               <span className="absolute inset-0 rounded-xl pointer-events-none animate-pulse-ring" />
             )}
             <span className="relative"></span>
-            <span className="relative"></span>
           </button>
         </div>
         {audioVisible && (
@@ -1197,7 +842,6 @@ export default function InteractiveCanvas() {
             setVolume={setVolume}
           />
         )}
-        {/* Player YouTube (toujours mont pour conserver la lecture) */}
         {/* Player YouTube (toujours mont pour conserver la lecture) */}
         {ytId && (
           <YouTube
@@ -1246,14 +890,12 @@ export default function InteractiveCanvas() {
             >
               <img
                 src={img.url}
-                src={img.url}
                 alt="Envoi en cours"
                 className="w-full h-full object-contain rounded-2xl opacity-80"
               />
             </div>
           ))}
 
-          {imagesToRender.map((img) => (
           {imagesToRender.map((img) => (
             <ImageItem
               key={img.id}
@@ -1284,9 +926,7 @@ export default function InteractiveCanvas() {
           <SideNotes />
 
           {/* DiceHub supprim : les lancers de ds ne sont plus synchroniss globalement */}
-          {/* DiceHub supprim : les lancers de ds ne sont plus synchroniss globalement */}
         </div>{' '}
-        {/*  fin du conteneur relatif */}
         {/*  fin du conteneur relatif */}
       </div>
 


### PR DESCRIPTION
## Summary
- remove the duplicated sections that were appended to `InteractiveCanvas` during the last merge
- restore the original canvas logic so the component compiles again

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e39c7bcbe0832e89c42c5d24d522db